### PR TITLE
Bump guest memory limit to 6GB on 8GB devices

### DIFF
--- a/VirtualMac/vz/host/VZVMLibraryViewController.m
+++ b/VirtualMac/vz/host/VZVMLibraryViewController.m
@@ -66,7 +66,7 @@ NSString *VZInstallationsPath(void)
 static uint64_t VZDeviceMemoryLimit(void)
 {
     uint64_t physical = NSProcessInfo.processInfo.physicalMemory;
-    return physical >= GiB(12) ? GiB(8) : GiB(4);
+    return physical >= GiB(12) ? GiB(8) : GiB(6);
 }
 
 static uint64_t VZDefaultStorageSize(void)

--- a/VirtualMac/vz/host/VirtualMacApp.m
+++ b/VirtualMac/vz/host/VirtualMacApp.m
@@ -2718,7 +2718,7 @@ static id makeConfiguration(NSString *bundlePath, NSDictionary *options,
     NSUInteger cpuCount = [options[@"CPUCount"] unsignedIntegerValue];
     cpuCount = MAX((NSUInteger)2, MIN(cpuCount, hostCPUCount));
     uint64_t memoryLimit = NSProcessInfo.processInfo.physicalMemory >=
-        (12ULL << 30) ? (8ULL << 30) : (4ULL << 30);
+        (12ULL << 30) ? (8ULL << 30) : (6ULL << 30);
     uint64_t memorySize = [options[@"MemorySize"] unsignedLongLongValue];
     memorySize = MAX((2ULL << 30), MIN(memorySize, memoryLimit));
     ((void(*)(id, SEL, NSUInteger))objc_msgSend)(


### PR DESCRIPTION
Tested on an iPad14,5 on 16.3.1

Loaded up the guest and did not get jetsamed.