### PR TITLE
Force rm/mv in build scripts to avoid interactive prompts

### DIFF
--- a/VirtualMac/scripts/build-ipad-network-helpers.sh
+++ b/VirtualMac/scripts/build-ipad-network-helpers.sh
@@ -61,7 +61,7 @@ for name in bootpd rtadvd; do
     codesign --force --sign - --entitlements "$ENTS" \
         --generate-entitlement-der "$OUT/$name"
     codesign --verify --strict "$OUT/$name"
-    rm "$OUT/$name.macos"
+    rm -f "$OUT/$name.macos"
 done
 
 "$VZ_BUILD_ROOT/toolchain/venv/bin/python3" "$COMPAT_PATCH" "$BOOTPD"

--- a/VirtualMac/scripts/build-ipad-network-sharing.sh
+++ b/VirtualMac/scripts/build-ipad-network-sharing.sh
@@ -65,7 +65,7 @@ install_name_tool \
 codesign --force --sign - --entitlements "$ENTS" \
     --generate-entitlement-der "$BIN"
 ldid -S "$AUTH_COMPAT"
-rm "$BIN.macos"
+rm -f "$BIN.macos"
 
 cp "$SOURCE_PLIST" "$PLIST"
 plutil -remove ProgramArguments "$PLIST"

--- a/VirtualMac/scripts/build-ipad-vm.sh
+++ b/VirtualMac/scripts/build-ipad-vm.sh
@@ -164,7 +164,7 @@ xcrun --sdk iphoneos clang \
 
 "$VZ_BUILD_ROOT/toolchain/venv/bin/python3" \
     "$VZ_REPO_ROOT/vz/stamp_ios.py" "$VMM_BIN" "$VMM_BIN.ios" 16.0
-mv "$VMM_BIN.ios" "$VMM_BIN"
+mv -f "$VMM_BIN.ios" "$VMM_BIN"
 
 install_name_tool \
     -change \


### PR DESCRIPTION
The network-helper, network-sharing, and VM payload builds extract Apple system binaries via `lipo -thin` and stamp them with stamp_ios.py.

These outputs inherit the source's read-only mode (r-xr-xr-x), so plain `rm`/`mv` on them print an interactive override prompt and stall the build waiting for input.