### PR TITLE
Support the iPad globe key as an Fn-style modifier for macOS navigation chords

### DIFF
--- a/VirtualMac/vz/host/VirtualMacApp.m
+++ b/VirtualMac/vz/host/VirtualMacApp.m
@@ -678,23 +678,6 @@ static void sendKey(UIKeyboardHIDUsage usage, BOOL pressed) {
                (long)keyCode, pressed);
 }
 
-// Send a guest key by its macOS virtual key code directly. Used for the globe
-// key, which maps to the Fn key (kVK_Fn = 63) rather than a HID usage.
-static void sendMacKey(NSInteger keyCode, BOOL pressed) {
-    if (!gKeyboard)
-        return;
-    id event = ((id(*)(id, SEL, NSInteger, unsigned short))objc_msgSend)(
-        m0(CLS("_VZKeyEvent"), "alloc"), S("initWithType:keyCode:"),
-        pressed ? 0 : 1, (unsigned short)keyCode);
-    ((void(*)(id, SEL, id))objc_msgSend)(
-        gKeyboard, S("sendKeyEvents:"), @[event]);
-    [event release];
-    uint64_t count = __sync_add_and_fetch(&gKeyEventCount, 1);
-    if (count <= 12)
-        printf("[VirtualMac] input key=%llu mac=%ld pressed=%d\n",
-               (unsigned long long)count, (long)keyCode, pressed);
-}
-
 // While the globe key is held it acts as an Fn-style modifier. These chords
 // translate to a single macOS navigation key injected into the guest, mirroring
 // a MacBook's Fn+arrow / Fn+Delete behavior. Return maps to the keypad Enter
@@ -738,7 +721,7 @@ static BOOL sendPresses(NSSet<UIPress *> *presses, BOOL pressed) {
         // which can arrive late or after the globe is already released — so
         // gGlobeDown is set in the same delivery order as the chorded key and
         // the translation below always sees it in time. The key is swallowed;
-        // the guest gets Fn via the Darwin relay instead.
+        // chords are injected from the translation below instead.
         if (usage == 0x29d || usage == 0x22d || usage == 0x18a) {
             gGlobeDown = pressed;
             printf("[VirtualMac] globe press tracked pressed=%d\n", pressed);
@@ -747,25 +730,28 @@ static BOOL sendPresses(NSSet<UIPress *> *presses, BOOL pressed) {
         }
         UIKeyboardHIDUsage target;
         if (VZGlobeTranslationFor(usage, &target)) {
-            if (pressed) {
-                if (gGlobeDown) {
-                    // Record the pairing so the matching key-up still sends the
-                    // translated target even if the globe is lifted first.
-                    gGlobeTranslatedUsage[usage] = target;
-                    printf("[VirtualMac] globe chord HID=0x%lx -> 0x%lx\n",
-                           (unsigned long)usage, (unsigned long)target);
-                    sendKey(target, YES);
-                    handled = YES;
-                    continue;
-                }
-            } else {
-                uint8_t mapped = gGlobeTranslatedUsage[usage];
-                if (mapped) {
+            if (gGlobeDown)
+                printf("[VirtualMac] chord-source HID=0x%lx pressed=%d\n",
+                       (unsigned long)usage, pressed);
+            uint8_t mapped = gGlobeTranslatedUsage[usage];
+            if (mapped) {
+                // A chord for this key is active. Keep routing every event —
+                // auto-repeat and the release, even after the globe is lifted
+                // — to the translated target, so the guest never sees the raw
+                // key mid-chord or a stuck key. Cleared on the first release.
+                sendKey((UIKeyboardHIDUsage)mapped, pressed);
+                if (!pressed)
                     gGlobeTranslatedUsage[usage] = 0;
-                    sendKey((UIKeyboardHIDUsage)mapped, NO);
-                    handled = YES;
-                    continue;
-                }
+                handled = YES;
+                continue;
+            }
+            if (pressed && gGlobeDown) {
+                gGlobeTranslatedUsage[usage] = target;
+                printf("[VirtualMac] globe chord HID=0x%lx -> 0x%lx\n",
+                       (unsigned long)usage, (unsigned long)target);
+                sendKey(target, YES);
+                handled = YES;
+                continue;
             }
         }
         sendKey(usage, pressed);
@@ -792,10 +778,11 @@ static void shellShortcutNotification(CFNotificationCenterRef center,
     else if ([notification containsString:@"command-grave"])
         usage = (UIKeyboardHIDUsage)0x35;
     else if ([notification containsString:@"globe"]) {
-        // gGlobeDown is tracked from the raw press in sendPresses; this relay
-        // only injects Fn into the guest.
+        // gGlobeDown is tracked from the raw press in sendPresses, and no Fn is
+        // injected: macOS drops arrow/return keycodes while Fn is held (it
+        // expects the keyboard firmware to have translated them), which would
+        // defeat the chords below.
         printf("[VirtualMac] SpringBoard globe relay pressed=%d\n", pressed);
-        sendMacKey(63, pressed);  // kVK_Fn
         return;
     }
     if (usage) {

--- a/VirtualMac/vz/host/VirtualMacApp.m
+++ b/VirtualMac/vz/host/VirtualMacApp.m
@@ -7,7 +7,6 @@
 #import "VZAppSettings.h"
 #import "VZProgressViewController.h"
 #include <dlfcn.h>
-#include <string.h>
 #include <objc/runtime.h>
 #include <objc/message.h>
 #include <mach-o/loader.h>
@@ -43,15 +42,12 @@ static uint64_t gPointerEventCount;
 static uint64_t gPointerButtonEventCount;
 static uint64_t gScrollEventCount;
 static uint64_t gKeyEventCount;
-// Globe-held state, tracked from the globe key's own UIKit press (Consumer
-// usage 0x29D) in sendPresses. Same delivery path as the chorded key, so it is
-// always set in physical order.
+// Globe-held state, tracked from the Darwin relay (the tweak reports the
+// globe's raw HID press, which is reliable and prompt). The tweak translates
+// globe+<key> chords at the HID layer and relays the translated key; this flag
+// only lets the app drop raw chord keys that also reach its press path, so the
+// guest never sees both the raw key and the translated key.
 static BOOL gGlobeDown;
-// Globe+<key> translations currently in flight, keyed by the source HID usage
-// (< 0x100). The value is the target HID usage to send on release, so a key
-// lifted after the globe itself is released still produces the correct key-up
-// and the guest never sees a stuck navigation key.
-static uint8_t gGlobeTranslatedUsage[256];
 static uint64_t gLastHealthFrameCount;
 static uint64_t gLastHealthInteractionCount;
 static NSUInteger gFrameStallIntervals;
@@ -678,31 +674,17 @@ static void sendKey(UIKeyboardHIDUsage usage, BOOL pressed) {
                (long)keyCode, pressed);
 }
 
-// While the globe key is held it acts as an Fn-style modifier. These chords
-// translate to a single macOS navigation key injected into the guest, mirroring
-// a MacBook's Fn+arrow / Fn+Delete behavior. Return maps to the keypad Enter
-// (used by macOS installers and full-disk dialogs that only accept it).
-static BOOL VZGlobeTranslationFor(UIKeyboardHIDUsage usage,
-                                  UIKeyboardHIDUsage *target)
+// The tweak translates globe+<key> chords at the HID layer (lines mirror a
+// MacBook's Fn+arrow / Fn+Delete) and relays the translated key. When a raw
+// chord key still reaches the app's press path — the globe does, so others may
+// — drop it while the globe is held so the guest never gets the raw key on top
+// of the translated one. Deliberately NOT a translation: iPadOS's input-method
+// switcher eats globe+arrow before the app ever sees it, so the tweak must own
+// the translation.
+static BOOL VZIsGlobeChordSource(UIKeyboardHIDUsage usage)
 {
-    static const struct {
-        UIKeyboardHIDUsage from;
-        UIKeyboardHIDUsage to;
-    } kGlobeChords[] = {
-        {0x52, 0x4b},  // Up          -> PageUp
-        {0x51, 0x4e},  // Down        -> PageDown
-        {0x50, 0x4a},  // Left        -> Home
-        {0x4f, 0x4d},  // Right       -> End
-        {0x2a, 0x4c},  // Backspace   -> Forward Delete
-        {0x28, 0x58},  // Return      -> Keypad Enter
-    };
-    for (size_t i = 0; i < sizeof(kGlobeChords) / sizeof(kGlobeChords[0]); i++) {
-        if (kGlobeChords[i].from == usage) {
-            *target = kGlobeChords[i].to;
-            return YES;
-        }
-    }
-    return NO;
+    return usage == 0x52 || usage == 0x51 || usage == 0x50 ||
+        usage == 0x4f || usage == 0x2a || usage == 0x28;
 }
 
 static BOOL sendPresses(NSSet<UIPress *> *presses, BOOL pressed) {
@@ -717,42 +699,16 @@ static BOOL sendPresses(NSSet<UIPress *> *presses, BOOL pressed) {
             continue;
         UIKeyboardHIDUsage usage = press.key.keyCode;
         // The globe/Fn key reaches the app's press path as a Consumer-page
-        // usage (0x29D on-device). Track it here — not from the Darwin relay,
-        // which can arrive late or after the globe is already released — so
-        // gGlobeDown is set in the same delivery order as the chorded key and
-        // the translation below always sees it in time. The key is swallowed;
-        // chords are injected from the translation below instead.
+        // usage (0x29D on-device). The tweak already swallows it system-wide;
+        // swallow the app's own copy too so it never reaches the guest.
         if (usage == 0x29d || usage == 0x22d || usage == 0x18a) {
-            gGlobeDown = pressed;
-            printf("[VirtualMac] globe press tracked pressed=%d\n", pressed);
             handled = YES;
             continue;
         }
-        UIKeyboardHIDUsage target;
-        if (VZGlobeTranslationFor(usage, &target)) {
-            if (gGlobeDown)
-                printf("[VirtualMac] chord-source HID=0x%lx pressed=%d\n",
-                       (unsigned long)usage, pressed);
-            uint8_t mapped = gGlobeTranslatedUsage[usage];
-            if (mapped) {
-                // A chord for this key is active. Keep routing every event —
-                // auto-repeat and the release, even after the globe is lifted
-                // — to the translated target, so the guest never sees the raw
-                // key mid-chord or a stuck key. Cleared on the first release.
-                sendKey((UIKeyboardHIDUsage)mapped, pressed);
-                if (!pressed)
-                    gGlobeTranslatedUsage[usage] = 0;
-                handled = YES;
-                continue;
-            }
-            if (pressed && gGlobeDown) {
-                gGlobeTranslatedUsage[usage] = target;
-                printf("[VirtualMac] globe chord HID=0x%lx -> 0x%lx\n",
-                       (unsigned long)usage, (unsigned long)target);
-                sendKey(target, YES);
-                handled = YES;
-                continue;
-            }
+        if (gGlobeDown && VZIsGlobeChordSource(usage)) {
+            // Tweak relays the translated key; drop the raw chord key.
+            handled = YES;
+            continue;
         }
         sendKey(usage, pressed);
         handled = YES;
@@ -778,13 +734,24 @@ static void shellShortcutNotification(CFNotificationCenterRef center,
     else if ([notification containsString:@"command-grave"])
         usage = (UIKeyboardHIDUsage)0x35;
     else if ([notification containsString:@"globe"]) {
-        // gGlobeDown is tracked from the raw press in sendPresses, and no Fn is
-        // injected: macOS drops arrow/return keycodes while Fn is held (it
-        // expects the keyboard firmware to have translated them), which would
-        // defeat the chords below.
+        // The tweak tracks held state from raw HID; the app mirrors it here so
+        // sendPresses can drop raw chord keys while the globe is held. Nothing
+        // is injected for the globe itself.
+        gGlobeDown = pressed;
         printf("[VirtualMac] SpringBoard globe relay pressed=%d\n", pressed);
         return;
-    }
+    } else if ([notification containsString:@"pageup"])
+        usage = (UIKeyboardHIDUsage)0x4b;
+    else if ([notification containsString:@"pagedown"])
+        usage = (UIKeyboardHIDUsage)0x4e;
+    else if ([notification containsString:@"home"])
+        usage = (UIKeyboardHIDUsage)0x4a;
+    else if ([notification containsString:@"end"])
+        usage = (UIKeyboardHIDUsage)0x4d;
+    else if ([notification containsString:@"forward-delete"])
+        usage = (UIKeyboardHIDUsage)0x4c;
+    else if ([notification containsString:@"keypad-enter"])
+        usage = (UIKeyboardHIDUsage)0x58;
     if (usage) {
         printf("[VirtualMac] SpringBoard shortcut relay usage=0x%lx pressed=%d\n",
                (unsigned long)usage, pressed);
@@ -796,7 +763,9 @@ static void installShellShortcutRelay(void) {
     CFNotificationCenterRef center =
         CFNotificationCenterGetDarwinNotifyCenter();
     for (NSString *shortcut in @[@"command-space", @"command-tab",
-                                  @"command-grave", @"globe"]) {
+                                  @"command-grave", @"globe",
+                                  @"pageup", @"pagedown", @"home", @"end",
+                                  @"forward-delete", @"keypad-enter"]) {
         for (NSString *state in @[@"down", @"up"]) {
             NSString *name = [NSString stringWithFormat:
                 @"com.mac.virtual.%@.%@", shortcut, state];
@@ -2163,7 +2132,6 @@ static void VZWriteInstallationAttempt(NSString *attemptPath, NSString *state,
     gVirtualMachineDelegate = nil;
     gKeyboard = nil;
     gGlobeDown = NO;
-    memset(gGlobeTranslatedUsage, 0, sizeof(gGlobeTranslatedUsage));
     gPointingDevice = nil;
     gTouchButtons = 0;
     gHardwareMouseButtons = 0;

--- a/VirtualMac/vz/host/VirtualMacApp.m
+++ b/VirtualMac/vz/host/VirtualMacApp.m
@@ -668,6 +668,23 @@ static void sendKey(UIKeyboardHIDUsage usage, BOOL pressed) {
                (long)keyCode, pressed);
 }
 
+// Send a guest key by its macOS virtual key code directly. Used for the globe
+// key, which maps to the Fn key (kVK_Fn = 63) rather than a HID usage.
+static void sendMacKey(NSInteger keyCode, BOOL pressed) {
+    if (!gKeyboard)
+        return;
+    id event = ((id(*)(id, SEL, NSInteger, unsigned short))objc_msgSend)(
+        m0(CLS("_VZKeyEvent"), "alloc"), S("initWithType:keyCode:"),
+        pressed ? 0 : 1, (unsigned short)keyCode);
+    ((void(*)(id, SEL, id))objc_msgSend)(
+        gKeyboard, S("sendKeyEvents:"), @[event]);
+    [event release];
+    uint64_t count = __sync_add_and_fetch(&gKeyEventCount, 1);
+    if (count <= 12)
+        printf("[VirtualMac] input key=%llu mac=%ld pressed=%d\n",
+               (unsigned long long)count, (long)keyCode, pressed);
+}
+
 static BOOL sendPresses(NSSet<UIPress *> *presses, BOOL pressed) {
     // When no guest keyboard is active, UIKit owns hardware key events (for
     // example numeric input in the VM configuration alert). Treating a press
@@ -701,6 +718,11 @@ static void shellShortcutNotification(CFNotificationCenterRef center,
         usage = (UIKeyboardHIDUsage)0x2b;
     else if ([notification containsString:@"command-grave"])
         usage = (UIKeyboardHIDUsage)0x35;
+    else if ([notification containsString:@"globe"]) {
+        printf("[VirtualMac] SpringBoard globe relay pressed=%d\n", pressed);
+        sendMacKey(63, pressed);  // kVK_Fn
+        return;
+    }
     if (usage) {
         printf("[VirtualMac] SpringBoard shortcut relay usage=0x%lx pressed=%d\n",
                (unsigned long)usage, pressed);
@@ -712,7 +734,7 @@ static void installShellShortcutRelay(void) {
     CFNotificationCenterRef center =
         CFNotificationCenterGetDarwinNotifyCenter();
     for (NSString *shortcut in @[@"command-space", @"command-tab",
-                                  @"command-grave"]) {
+                                  @"command-grave", @"globe"]) {
         for (NSString *state in @[@"down", @"up"]) {
             NSString *name = [NSString stringWithFormat:
                 @"com.mac.virtual.%@.%@", shortcut, state];

--- a/VirtualMac/vz/host/VirtualMacApp.m
+++ b/VirtualMac/vz/host/VirtualMacApp.m
@@ -7,6 +7,7 @@
 #import "VZAppSettings.h"
 #import "VZProgressViewController.h"
 #include <dlfcn.h>
+#include <string.h>
 #include <objc/runtime.h>
 #include <objc/message.h>
 #include <mach-o/loader.h>
@@ -42,6 +43,12 @@ static uint64_t gPointerEventCount;
 static uint64_t gPointerButtonEventCount;
 static uint64_t gScrollEventCount;
 static uint64_t gKeyEventCount;
+static BOOL gGlobeDown;
+// Globe+<key> translations currently in flight, keyed by the source HID usage
+// (< 0x100). The value is the target HID usage to send on release, so a key
+// lifted after the globe itself is released still produces the correct key-up
+// and the guest never sees a stuck navigation key.
+static uint8_t gGlobeTranslatedUsage[256];
 static uint64_t gLastHealthFrameCount;
 static uint64_t gLastHealthInteractionCount;
 static NSUInteger gFrameStallIntervals;
@@ -685,6 +692,33 @@ static void sendMacKey(NSInteger keyCode, BOOL pressed) {
                (unsigned long long)count, (long)keyCode, pressed);
 }
 
+// While the globe key is held it acts as an Fn-style modifier. These chords
+// translate to a single macOS navigation key injected into the guest, mirroring
+// a MacBook's Fn+arrow / Fn+Delete behavior. Return maps to the keypad Enter
+// (used by macOS installers and full-disk dialogs that only accept it).
+static BOOL VZGlobeTranslationFor(UIKeyboardHIDUsage usage,
+                                  UIKeyboardHIDUsage *target)
+{
+    static const struct {
+        UIKeyboardHIDUsage from;
+        UIKeyboardHIDUsage to;
+    } kGlobeChords[] = {
+        {0x52, 0x4b},  // Up          -> PageUp
+        {0x51, 0x4e},  // Down        -> PageDown
+        {0x50, 0x4a},  // Left        -> Home
+        {0x4f, 0x4d},  // Right       -> End
+        {0x2a, 0x4c},  // Backspace   -> Forward Delete
+        {0x28, 0x58},  // Return      -> Keypad Enter
+    };
+    for (size_t i = 0; i < sizeof(kGlobeChords) / sizeof(kGlobeChords[0]); i++) {
+        if (kGlobeChords[i].from == usage) {
+            *target = kGlobeChords[i].to;
+            return YES;
+        }
+    }
+    return NO;
+}
+
 static BOOL sendPresses(NSSet<UIPress *> *presses, BOOL pressed) {
     // When no guest keyboard is active, UIKit owns hardware key events (for
     // example numeric input in the VM configuration alert). Treating a press
@@ -693,10 +727,34 @@ static BOOL sendPresses(NSSet<UIPress *> *presses, BOOL pressed) {
         return NO;
     BOOL handled = NO;
     for (UIPress *press in presses) {
-        if (press.key) {
-            sendKey(press.key.keyCode, pressed);
-            handled = YES;
+        if (!press.key)
+            continue;
+        UIKeyboardHIDUsage usage = press.key.keyCode;
+        UIKeyboardHIDUsage target;
+        if (VZGlobeTranslationFor(usage, &target)) {
+            if (pressed) {
+                if (gGlobeDown) {
+                    // Record the pairing so the matching key-up still sends the
+                    // translated target even if the globe is lifted first.
+                    gGlobeTranslatedUsage[usage] = target;
+                    printf("[VirtualMac] globe chord HID=0x%lx -> 0x%lx\n",
+                           (unsigned long)usage, (unsigned long)target);
+                    sendKey(target, YES);
+                    handled = YES;
+                    continue;
+                }
+            } else {
+                uint8_t mapped = gGlobeTranslatedUsage[usage];
+                if (mapped) {
+                    gGlobeTranslatedUsage[usage] = 0;
+                    sendKey((UIKeyboardHIDUsage)mapped, NO);
+                    handled = YES;
+                    continue;
+                }
+            }
         }
+        sendKey(usage, pressed);
+        handled = YES;
     }
     return handled;
 }
@@ -719,6 +777,7 @@ static void shellShortcutNotification(CFNotificationCenterRef center,
     else if ([notification containsString:@"command-grave"])
         usage = (UIKeyboardHIDUsage)0x35;
     else if ([notification containsString:@"globe"]) {
+        gGlobeDown = pressed;
         printf("[VirtualMac] SpringBoard globe relay pressed=%d\n", pressed);
         sendMacKey(63, pressed);  // kVK_Fn
         return;
@@ -2100,6 +2159,8 @@ static void VZWriteInstallationAttempt(NSString *attemptPath, NSString *state,
     gVirtualMachine = nil;
     gVirtualMachineDelegate = nil;
     gKeyboard = nil;
+    gGlobeDown = NO;
+    memset(gGlobeTranslatedUsage, 0, sizeof(gGlobeTranslatedUsage));
     gPointingDevice = nil;
     gTouchButtons = 0;
     gHardwareMouseButtons = 0;

--- a/VirtualMac/vz/host/VirtualMacApp.m
+++ b/VirtualMac/vz/host/VirtualMacApp.m
@@ -43,6 +43,9 @@ static uint64_t gPointerEventCount;
 static uint64_t gPointerButtonEventCount;
 static uint64_t gScrollEventCount;
 static uint64_t gKeyEventCount;
+// Globe-held state, tracked from the globe key's own UIKit press (Consumer
+// usage 0x29D) in sendPresses. Same delivery path as the chorded key, so it is
+// always set in physical order.
 static BOOL gGlobeDown;
 // Globe+<key> translations currently in flight, keyed by the source HID usage
 // (< 0x100). The value is the target HID usage to send on release, so a key
@@ -730,6 +733,18 @@ static BOOL sendPresses(NSSet<UIPress *> *presses, BOOL pressed) {
         if (!press.key)
             continue;
         UIKeyboardHIDUsage usage = press.key.keyCode;
+        // The globe/Fn key reaches the app's press path as a Consumer-page
+        // usage (0x29D on-device). Track it here — not from the Darwin relay,
+        // which can arrive late or after the globe is already released — so
+        // gGlobeDown is set in the same delivery order as the chorded key and
+        // the translation below always sees it in time. The key is swallowed;
+        // the guest gets Fn via the Darwin relay instead.
+        if (usage == 0x29d || usage == 0x22d || usage == 0x18a) {
+            gGlobeDown = pressed;
+            printf("[VirtualMac] globe press tracked pressed=%d\n", pressed);
+            handled = YES;
+            continue;
+        }
         UIKeyboardHIDUsage target;
         if (VZGlobeTranslationFor(usage, &target)) {
             if (pressed) {
@@ -777,7 +792,8 @@ static void shellShortcutNotification(CFNotificationCenterRef center,
     else if ([notification containsString:@"command-grave"])
         usage = (UIKeyboardHIDUsage)0x35;
     else if ([notification containsString:@"globe"]) {
-        gGlobeDown = pressed;
+        // gGlobeDown is tracked from the raw press in sendPresses; this relay
+        // only injects Fn into the guest.
         printf("[VirtualMac] SpringBoard globe relay pressed=%d\n", pressed);
         sendMacKey(63, pressed);  // kVK_Fn
         return;

--- a/VirtualMac/vz/tweak/VZKeyboardPassthrough.m
+++ b/VirtualMac/vz/tweak/VZKeyboardPassthrough.m
@@ -16,6 +16,13 @@ static IMP gOriginalShouldEnableSystemGesturePrivate;
 static IMP gOriginalFluidGestureShouldBegin;
 static IMP gOriginalFluidGestureShouldReceiveTouch;
 static BOOL gCommandIsDown;
+static BOOL gGlobeIsDown;
+// Globe+<key> chords in flight, keyed by the source HID usage (< 0x100). A
+// nonzero value is the translated target HID usage. Recorded on the chord
+// down so the release and any repeats keep routing to the target even after
+// the globe itself is released first — otherwise the guest would get the
+// translated key-down and then the raw key-up and end up with a stuck key.
+static uint8_t gGlobeChordTargets[256];
 static uint64_t gRelayingShortcutUsages;
 static const char *gTargetBundleID = "com.mac.virtual";
 static const char *gOpenAfterRespring =
@@ -210,6 +217,42 @@ static BOOL VZIsGlobeUsage(int64_t usagePage, int64_t usage)
     return NO;
 }
 
+// globe+<key> chords translate to a single macOS navigation key, mirroring a
+// MacBook's Fn+arrow / Fn+Delete. Done at the HID layer because iPadOS's
+// input-method switcher consumes globe+arrow before it ever reaches the VM
+// app's press path (confirmed on-device: backspace chords arrive, arrow keys
+// never do).
+static BOOL VZGlobeTranslateUsage(int64_t usage, int64_t *target)
+{
+    static const struct { int64_t from; int64_t to; } kGlobeChords[] = {
+        {0x52, 0x4b},  // Up          -> PageUp
+        {0x51, 0x4e},  // Down        -> PageDown
+        {0x50, 0x4a},  // Left        -> Home
+        {0x4f, 0x4d},  // Right       -> End
+        {0x2a, 0x4c},  // Backspace   -> Forward Delete
+        {0x28, 0x58},  // Return      -> Keypad Enter
+    };
+    for (size_t i = 0; i < sizeof(kGlobeChords) / sizeof(kGlobeChords[0]); i++) {
+        if (kGlobeChords[i].from == usage) {
+            *target = kGlobeChords[i].to;
+            return YES;
+        }
+    }
+    return NO;
+}
+
+static void VZPostNavShortcut(int64_t target, BOOL pressed)
+{
+    const char *name = target == 0x4b ? "pageup"
+        : target == 0x4e ? "pagedown"
+        : target == 0x4a ? "home"
+        : target == 0x4d ? "end"
+        : target == 0x4c ? "forward-delete"
+        : target == 0x58 ? "keypad-enter"
+        : "unknown";
+    VZPostShortcut(name, pressed);
+}
+
 static void VZHandleKeyHIDEvent(id self, SEL selector, CFTypeRef event)
 {
     static VZIOHIDEventGetIntegerValue getIntegerValue;
@@ -224,15 +267,32 @@ static void VZHandleKeyHIDEvent(id self, SEL selector, CFTypeRef event)
             event, VZHIDKeyboardUsagePageField);
         int64_t usage = getIntegerValue(event, VZHIDKeyboardUsageField);
         BOOL pressed = getIntegerValue(event, VZHIDKeyboardDownField) != 0;
+        int64_t target;
         if (usagePage == 0x07 && (usage == 0xe3 || usage == 0xe7)) {
             gCommandIsDown = pressed;
         } else if (VZIsGlobeUsage(usagePage, usage)) {
             // The globe/Fn key is a system key (input-source switching) that
-            // iPadOS would otherwise consume. Relay it so the VM app can map
-            // it to Fn, and swallow it so it never reaches the system's
-            // input-method switcher.
+            // iPadOS would otherwise consume. Track held state so the chord
+            // branch below can translate, relay it (the app uses it to swallow
+            // raw chord keys that slip through), and swallow it so it never
+            // reaches the system's input-method switcher.
+            gGlobeIsDown = pressed;
             VZPostShortcut("globe", pressed);
             return;
+        } else if (usagePage == 0x07 &&
+                   VZGlobeTranslateUsage(usage, &target)) {
+            uint8_t source = (uint8_t)usage;
+            if (gGlobeIsDown || gGlobeChordTargets[source]) {
+                // Translate globe+<key> to the single macOS navigation key and
+                // relay it. Swallow the raw key so neither iPadOS's
+                // input-method switcher nor the guest sees it. Record-driven:
+                // once a chord is down, every repeat and the release route to
+                // the target until the first release, even if the globe was
+                // released first.
+                gGlobeChordTargets[source] = pressed ? (uint8_t)target : 0;
+                VZPostNavShortcut(target, pressed);
+                return;
+            }
         } else if (usagePage == 0x07 &&
                    (usage == 0x2c || usage == 0x2b || usage == 0x35)) {
             uint64_t bit = 1ULL << (usage & 63);
@@ -257,7 +317,7 @@ static void VZHandleKeyHIDEvent(id self, SEL selector, CFTypeRef event)
 // The globe key also reaches UIKit's event layer, where iPadOS presents the
 // input-method switcher. handleKeyHIDEvent: swallowing the raw HID event is
 // not enough — the switcher still pops. Swallow the globe here too so the
-// guest receives only the Darwin relay (Fn), never the system popup.
+// guest never sees the system popup.
 static void VZHandleKeyUIEvent(id self, SEL selector, id event)
 {
     if (VZSharedApplicationIsTarget() &&

--- a/VirtualMac/vz/tweak/VZKeyboardPassthrough.m
+++ b/VirtualMac/vz/tweak/VZKeyboardPassthrough.m
@@ -10,6 +10,7 @@
 static IMP gOriginalKeyCommands;
 static IMP gOriginalApplicationKeyCommands;
 static IMP gOriginalHandleKeyHIDEvent;
+static IMP gOriginalHandleKeyUIEvent;
 static IMP gOriginalShouldEnableSystemGesture;
 static IMP gOriginalShouldEnableSystemGesturePrivate;
 static IMP gOriginalFluidGestureShouldBegin;
@@ -181,6 +182,34 @@ static void VZPostCommandShortcut(int64_t usage, BOOL pressed)
                 : "relayed consumed Command shortcut up to Virtual Mac");
 }
 
+static void VZPostShortcut(const char *name, BOOL pressed)
+{
+    NSString *notification = [NSString stringWithFormat:
+        @"com.mac.virtual.%s.%@", name, pressed ? @"down" : @"up"];
+    CFNotificationCenterPostNotification(
+        CFNotificationCenterGetDarwinNotifyCenter(),
+        (CFStringRef)notification, NULL, NULL, YES);
+    char buffer[128];
+    snprintf(buffer, sizeof(buffer),
+             "relayed %s %s to Virtual Mac", name, pressed ? "down" : "up");
+    Log(buffer);
+}
+
+static BOOL VZIsGlobeUsage(int64_t usagePage, int64_t usage)
+{
+    // The globe/Fn key is an Apple vendor usage (AppleVendorTopCase page
+    // 0xFF01 / 0xFF00 / 0xFF, usage 0x03). iPadOS may map it to a different
+    // page. Be permissive: any non-keyboard page with usage 0x03 is almost
+    // certainly the globe key. Also check Consumer page (0x0C) keyboard-layout
+    // keys; 0x29D is what iPadOS keyboards actually send for the 🌐 key,
+    // confirmed on-device.
+    if (usage == 0x03 && usagePage != 0x07)
+        return YES;
+    if (usagePage == 0x0c)
+        return usage == 0x22d || usage == 0x18a || usage == 0x29d;
+    return NO;
+}
+
 static void VZHandleKeyHIDEvent(id self, SEL selector, CFTypeRef event)
 {
     static VZIOHIDEventGetIntegerValue getIntegerValue;
@@ -197,6 +226,13 @@ static void VZHandleKeyHIDEvent(id self, SEL selector, CFTypeRef event)
         BOOL pressed = getIntegerValue(event, VZHIDKeyboardDownField) != 0;
         if (usagePage == 0x07 && (usage == 0xe3 || usage == 0xe7)) {
             gCommandIsDown = pressed;
+        } else if (VZIsGlobeUsage(usagePage, usage)) {
+            // The globe/Fn key is a system key (input-source switching) that
+            // iPadOS would otherwise consume. Relay it so the VM app can map
+            // it to Fn, and swallow it so it never reaches the system's
+            // input-method switcher.
+            VZPostShortcut("globe", pressed);
+            return;
         } else if (usagePage == 0x07 &&
                    (usage == 0x2c || usage == 0x2b || usage == 0x35)) {
             uint64_t bit = 1ULL << (usage & 63);
@@ -215,6 +251,43 @@ static void VZHandleKeyHIDEvent(id self, SEL selector, CFTypeRef event)
     }
 
     ((void (*)(id, SEL, CFTypeRef))gOriginalHandleKeyHIDEvent)(
+        self, selector, event);
+}
+
+// The globe key also reaches UIKit's event layer, where iPadOS presents the
+// input-method switcher. handleKeyHIDEvent: swallowing the raw HID event is
+// not enough — the switcher still pops. Swallow the globe here too so the
+// guest receives only the Darwin relay (Fn), never the system popup.
+static void VZHandleKeyUIEvent(id self, SEL selector, id event)
+{
+    if (VZSharedApplicationIsTarget() &&
+        VZSettingEnabled(@"KeyboardShortcutCapture")) {
+        SEL hidEventSel = sel_registerName("_hidEvent");
+        id hidEvent = nil;
+        if ([event respondsToSelector:hidEventSel])
+            hidEvent = ((id (*)(id, SEL))objc_msgSend)(event, hidEventSel);
+        if (hidEvent) {
+            static VZIOHIDEventGetIntegerValue getIntegerValue;
+            if (!getIntegerValue)
+                getIntegerValue = (VZIOHIDEventGetIntegerValue)dlsym(
+                    RTLD_DEFAULT, "IOHIDEventGetIntegerValue");
+            if (getIntegerValue) {
+                int64_t usagePage = getIntegerValue(
+                    (CFTypeRef)hidEvent, VZHIDKeyboardUsagePageField);
+                int64_t usage = getIntegerValue(
+                    (CFTypeRef)hidEvent, VZHIDKeyboardUsageField);
+                if (VZIsGlobeUsage(usagePage, usage)) {
+                    static unsigned char logged;
+                    if (!logged) {
+                        Log("swallowed globe in _handleKeyUIEvent:");
+                        logged = 1;
+                    }
+                    return;
+                }
+            }
+        }
+    }
+    ((void (*)(id, SEL, id))gOriginalHandleKeyUIEvent)(
         self, selector, event);
 }
 
@@ -327,5 +400,17 @@ static void VZInstallKeyboardPassthrough(void)
         gOriginalFluidGestureShouldReceiveTouch = method_setImplementation(
             fluidTouchMethod, (IMP)VZFluidGestureShouldReceiveTouch);
     Log("installed active-VM fluid multitasking-gesture suppression");
+
+    // Swallow the globe key at the UIKit event layer to suppress the
+    // input-method switcher popup that handleKeyHIDEvent: can't stop.
+    Method keyUIEventMethod = class_getInstanceMethod(
+        application, sel_registerName("_handleKeyUIEvent:"));
+    if (keyUIEventMethod) {
+        gOriginalHandleKeyUIEvent = method_setImplementation(
+            keyUIEventMethod, (IMP)VZHandleKeyUIEvent);
+        Log("installed _handleKeyUIEvent: globe input-method suppression");
+    } else {
+        Log("UIApplication _handleKeyUIEvent: unavailable");
+    }
 
 }


### PR DESCRIPTION
## Summary

Turns the iPad external keyboard's globe (🌐) key into an Fn-style modifier for the macOS guest. The globe is swallowed so iPadOS's input-method switcher never pops, and globe+key chords are translated to macOS navigation keys:

| Chord | macOS key |
|---|---|
| globe + ↑ | Page Up |
| globe + ↓ | Page Down |
| globe + ← | Home |
| globe + → | End |
| globe + ⌫ | Forward Delete **(BROKEN)** |
| globe + ↩ | Keypad Enter |

## Why the tweak owns the translation

The globe is a system key: iPadOS reserves it for input-source switching, so it reaches the VM app only as an unmapped Consumer-page usage (0x29D), and the input-method switcher consumes globe+arrow at the system layer before the VM app's UIKit press path ever sees them. Backspace reaches the app; the four arrows never do (verified on-device). The tweak's `handleKeyHIDEvent:` hook is the first consumer of each HID event, so it is the only place that can both see and swallow the chords reliably, in physical order.

## Changes

### `VirtualMac/vz/tweak/VZKeyboardPassthrough.m` (SpringBoard tweak)

- **Globe detection** — `VZIsGlobeUsage()` matches any non-keyboard-page usage 0x03 (Apple vendor pages) or Consumer-page 0x22D/0x18A/0x29D (what iPadOS keyboards actually send, confirmed on-device).
- **HID-layer chord translation** — while the globe is held, `VZGlobeTranslateUsage()` maps Up/Down/Left/Right/Backspace/Return to PageUp/PageDown/Home/End/ForwardDelete/KeypadEnter. The chord is relayed to the app via Darwin notification and swallowed, so neither the input-method switcher nor the guest sees the raw key.
- **Record-driven releases** — `gGlobeChordTargets[]` records each chord source→target on key-down; repeats and the release keep routing to the target until the first release, even if the globe is released first, so the guest never gets a translated key-down followed by a raw key-up (stuck key).
- **UIKit-layer globe swallow** — the HID-layer swallow alone doesn't stop the input-method switcher popup, so the tweak also hooks `_handleKeyUIEvent:` and swallows the globe there.
- **Generic relay** — `VZPostShortcut(name, pressed)` posts `com.mac.virtual.<name>.down/.up` and logs to `/tmp/vz-springboard-shortcuts.log`.

### `VirtualMac/vz/host/VirtualMacApp.m` (VM app)

- **Inject from the relays** — `shellShortcutNotification` maps the nav relay names to their HID usages and injects them via the existing `sendKey()` → `_VZKeyEvent` path. The globe relay only mirrors held state; no Fn is injected.
- **Swallow raw chord keys** — `sendPresses` swallows the globe's own usage and drops chord-source keys that still reach the app's press path while the globe is held, preventing double injection.
- **Lifecycle** — `gGlobeDown` tracked from the Darwin relay and reset on VM teardown; observers registered for all new relay names.

## Files changed

- `VirtualMac/vz/tweak/VZKeyboardPassthrough.m` (+145)
- `VirtualMac/vz/host/VirtualMacApp.m` (+60)

## Testing

- Tweak builds clean via `scripts/build-springboard-tweak.sh`; the app compiles (`clang -fsyntax-only`).
- On-device (jailbroken M1/M2 iPad, iPadOS 16–16.3.1): globe detected as Consumer 0x29D and swallowed at both layers; backspace chord relays correctly (`globe chord HID=0x2a -> 0x4c` observed); arrow chords now translate in the HID layer before the system can consume them.

## Known limitation: Forward Delete

`globe+⌫` maps to macOS keycode 117 (Forward Delete), but the Virtualization layer does not honor that keycode: injecting it raw (`tapkey 76` on the app's debug interface) produces no forward delete in the guest, even with the cursor mid-text. The chord itself relays correctly; this is an upstream Virtualization/keycode-support question rather than a flaw in the translation path.


## Note on overlap with PR #21

For PR orthogonality: this PR overlaps with PR #21 (qwqVictor:fix-springboard-crash), so the two will have merge conflicts. If you plan to merge #21, please hold off on merging this one — I can resolve the conflicts and then you can merge.