### PR TITLE
Fix grammar: wrong preposition in scripts README

### DIFF
--- a/VirtualMac/scripts/README.md
+++ b/VirtualMac/scripts/README.md
@@ -1,6 +1,6 @@
 # Scripts
 
-Run `../setup.sh` for a complete reproducible build. The scripts directly in this directory are the stages used by building a deb package; they may also be run individually after the environment has been prepared.
+Run `../setup.sh` for a complete reproducible build. The scripts directly in this directory are the stages used for building a deb package; they may also be run individually after the environment has been prepared.
 
 - `development/` contains USB deployment, bring-up, and interactive device/real-Mac helpers.
 - `tests/` contains test and benchmark harnesses.


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `VirtualMac/scripts/README.md` (line 3).

## Problem

The preposition 'by' is incorrect here; 'building' is a gerund expressing purpose, not agency. The stages are used FOR building (purpose), not BY building (agent).

The problematic text:

```
The scripts directly in this directory are the stages used by building a deb package
```

## Fix

Replaced with:

```
The scripts directly in this directory are the stages used for building a deb package
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text