### PR TITLE
Fullscreen mirroring with external display

### DIFF
--- a/VirtualMac/resources/Localizations/cs.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/cs.lproj/Localizable.strings
@@ -98,7 +98,7 @@
 "Force Shut Down" = "Vynutit vypnutí";
 "Force Shut Down Virtual Mac?" = "Vynutit vypnutí virtuálního Macu?";
 "Full Screen" = "Celá obrazovka";
-"Fullscreen Mirroring" = "Fullscreen Mirroring";
+"Fullscreen Mirroring" = "Celozrcadlové Zrcadlení";
 "General" = "Obecné";
 "Get Help" = "Nápověda";
 "Height" = "Výška";

--- a/VirtualMac/resources/Localizations/cs.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/cs.lproj/Localizable.strings
@@ -1,4 +1,3 @@
-/* Virtual Mac 1.1.1 localization. */
 " · Legacy" = " · Starší";
 "%.0f%% complete" = "%.0f %% dokončeno";
 "%@ CPU · %@ GB RAM · %llu GB · %@%@" = "%@ CPU · %@ GB RAM · %llu GB · %@%@";
@@ -99,6 +98,7 @@
 "Force Shut Down" = "Vynutit vypnutí";
 "Force Shut Down Virtual Mac?" = "Vynutit vypnutí virtuálního Macu?";
 "Full Screen" = "Celá obrazovka";
+"Fullscreen Mirroring" = "Fullscreen Mirroring";
 "General" = "Obecné";
 "Get Help" = "Nápověda";
 "Height" = "Výška";

--- a/VirtualMac/resources/Localizations/da.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/da.lproj/Localizable.strings
@@ -98,7 +98,7 @@
 "Force Shut Down" = "Gennemtving nedlukning";
 "Force Shut Down Virtual Mac?" = "Gennemtving nedlukning af Virtual Mac?";
 "Full Screen" = "Fuld skærm";
-"Fullscreen Mirroring" = "Fullscreen Mirroring";
+"Fullscreen Mirroring" = "Fuldskærms Spejling";
 "General" = "Generelt";
 "Get Help" = "Få hjælp";
 "Height" = "Højde";

--- a/VirtualMac/resources/Localizations/da.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/da.lproj/Localizable.strings
@@ -1,4 +1,3 @@
-/* Virtual Mac 1.1.1 localization. */
 " · Legacy" = " · Ældre";
 "%.0f%% complete" = "%.0f%% fuldført";
 "%@ CPU · %@ GB RAM · %llu GB · %@%@" = "%@ CPU · %@ GB RAM · %llu GB · %@%@";
@@ -99,6 +98,7 @@
 "Force Shut Down" = "Gennemtving nedlukning";
 "Force Shut Down Virtual Mac?" = "Gennemtving nedlukning af Virtual Mac?";
 "Full Screen" = "Fuld skærm";
+"Fullscreen Mirroring" = "Fullscreen Mirroring";
 "General" = "Generelt";
 "Get Help" = "Få hjælp";
 "Height" = "Højde";

--- a/VirtualMac/resources/Localizations/de.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/de.lproj/Localizable.strings
@@ -1,4 +1,3 @@
-/* Virtual Mac 1.1.1 localization. */
 " · Legacy" = " · Veraltet";
 "%.0f%% complete" = "%.0f%% abgeschlossen";
 "%@ CPU · %@ GB RAM · %llu GB · %@%@" = "%@ CPU · %@ GB RAM · %llu GB · %@%@";
@@ -99,6 +98,7 @@
 "Force Shut Down" = "Ausschalten erzwingen";
 "Force Shut Down Virtual Mac?" = "Ausschalten von Virtual Mac erzwingen?";
 "Full Screen" = "Vollbild";
+"Fullscreen Mirroring" = "Fullscreen Mirroring";
 "General" = "Allgemein";
 "Get Help" = "Hilfe";
 "Height" = "Höhe";

--- a/VirtualMac/resources/Localizations/de.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/de.lproj/Localizable.strings
@@ -98,7 +98,7 @@
 "Force Shut Down" = "Ausschalten erzwingen";
 "Force Shut Down Virtual Mac?" = "Ausschalten von Virtual Mac erzwingen?";
 "Full Screen" = "Vollbild";
-"Fullscreen Mirroring" = "Fullscreen Mirroring";
+"Fullscreen Mirroring" = "Vollbild-Spiegelung";
 "General" = "Allgemein";
 "Get Help" = "Hilfe";
 "Height" = "Höhe";

--- a/VirtualMac/resources/Localizations/el.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/el.lproj/Localizable.strings
@@ -1,4 +1,3 @@
-/* Virtual Mac 1.1.1 localization. */
 " · Legacy" = " · Παλαιό";
 "%.0f%% complete" = "Ολοκληρώθηκε το %.0f%%";
 "%@ CPU · %@ GB RAM · %llu GB · %@%@" = "%@ CPU · %@ GB RAM · %llu GB · %@%@";
@@ -99,6 +98,7 @@
 "Force Shut Down" = "Εξαναγκασμένος τερματισμός";
 "Force Shut Down Virtual Mac?" = "Εξαναγκασμένος τερματισμός Εικονικού Mac;";
 "Full Screen" = "Πλήρης οθόνη";
+"Fullscreen Mirroring" = "Fullscreen Mirroring";
 "General" = "Γενικά";
 "Get Help" = "Βοήθεια";
 "Height" = "Ύψος";

--- a/VirtualMac/resources/Localizations/el.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/el.lproj/Localizable.strings
@@ -98,7 +98,7 @@
 "Force Shut Down" = "Εξαναγκασμένος τερματισμός";
 "Force Shut Down Virtual Mac?" = "Εξαναγκασμένος τερματισμός Εικονικού Mac;";
 "Full Screen" = "Πλήρης οθόνη";
-"Fullscreen Mirroring" = "Fullscreen Mirroring";
+"Fullscreen Mirroring" = "Κατοπτρισμός Πλήρους Οθόνης";
 "General" = "Γενικά";
 "Get Help" = "Βοήθεια";
 "Height" = "Ύψος";

--- a/VirtualMac/resources/Localizations/en.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/en.lproj/Localizable.strings
@@ -1,4 +1,3 @@
-/* Virtual Mac 1.1.1 localization. */
 " · Legacy" = " · Legacy";
 "%.0f%% complete" = "%.0f%% complete";
 "%@ CPU · %@ GB RAM · %llu GB · %@%@" = "%@ CPU · %@ GB RAM · %llu GB · %@%@";
@@ -99,6 +98,7 @@
 "Force Shut Down" = "Force Shut Down";
 "Force Shut Down Virtual Mac?" = "Force Shut Down Virtual Mac?";
 "Full Screen" = "Full Screen";
+"Fullscreen Mirroring" = "Fullscreen Mirroring";
 "General" = "General";
 "Get Help" = "Get Help";
 "Height" = "Height";

--- a/VirtualMac/resources/Localizations/es.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/es.lproj/Localizable.strings
@@ -98,7 +98,7 @@
 "Force Shut Down" = "Forzar apagado";
 "Force Shut Down Virtual Mac?" = "¿Forzar el apagado de Virtual Mac?";
 "Full Screen" = "Pantalla completa";
-"Fullscreen Mirroring" = "Fullscreen Mirroring";
+"Fullscreen Mirroring" = "Duplicación a Pantalla Completa";
 "General" = "General";
 "Get Help" = "Obtener ayuda";
 "Height" = "Altura";

--- a/VirtualMac/resources/Localizations/es.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/es.lproj/Localizable.strings
@@ -1,4 +1,3 @@
-/* Virtual Mac 1.1.1 localization. */
 " · Legacy" = " · Antigua";
 "%.0f%% complete" = "%.0f %% completado";
 "%@ CPU · %@ GB RAM · %llu GB · %@%@" = "%@ CPU · %@ GB de RAM · %llu GB · %@%@";
@@ -99,6 +98,7 @@
 "Force Shut Down" = "Forzar apagado";
 "Force Shut Down Virtual Mac?" = "¿Forzar el apagado de Virtual Mac?";
 "Full Screen" = "Pantalla completa";
+"Fullscreen Mirroring" = "Fullscreen Mirroring";
 "General" = "General";
 "Get Help" = "Obtener ayuda";
 "Height" = "Altura";

--- a/VirtualMac/resources/Localizations/es_419.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/es_419.lproj/Localizable.strings
@@ -98,7 +98,7 @@
 "Force Shut Down" = "Forzar apagado";
 "Force Shut Down Virtual Mac?" = "¿Forzar el apagado de Virtual Mac?";
 "Full Screen" = "Pantalla completa";
-"Fullscreen Mirroring" = "Fullscreen Mirroring";
+"Fullscreen Mirroring" = "Duplicación a Pantalla Completa";
 "General" = "General";
 "Get Help" = "Obtener ayuda";
 "Height" = "Altura";

--- a/VirtualMac/resources/Localizations/es_419.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/es_419.lproj/Localizable.strings
@@ -1,4 +1,3 @@
-/* Virtual Mac 1.1.1 localization. */
 " · Legacy" = " · Antigua";
 "%.0f%% complete" = "%.0f %% completado";
 "%@ CPU · %@ GB RAM · %llu GB · %@%@" = "%@ CPU · %@ GB de RAM · %llu GB · %@%@";
@@ -99,6 +98,7 @@
 "Force Shut Down" = "Forzar apagado";
 "Force Shut Down Virtual Mac?" = "¿Forzar el apagado de Virtual Mac?";
 "Full Screen" = "Pantalla completa";
+"Fullscreen Mirroring" = "Fullscreen Mirroring";
 "General" = "General";
 "Get Help" = "Obtener ayuda";
 "Height" = "Altura";

--- a/VirtualMac/resources/Localizations/es_US.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/es_US.lproj/Localizable.strings
@@ -98,7 +98,7 @@
 "Force Shut Down" = "Forzar apagado";
 "Force Shut Down Virtual Mac?" = "¿Forzar el apagado de Virtual Mac?";
 "Full Screen" = "Pantalla completa";
-"Fullscreen Mirroring" = "Fullscreen Mirroring";
+"Fullscreen Mirroring" = "Duplicación a Pantalla Completa";
 "General" = "General";
 "Get Help" = "Obtener ayuda";
 "Height" = "Altura";

--- a/VirtualMac/resources/Localizations/es_US.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/es_US.lproj/Localizable.strings
@@ -1,4 +1,3 @@
-/* Virtual Mac 1.1.1 localization. */
 " · Legacy" = " · Antigua";
 "%.0f%% complete" = "%.0f %% completado";
 "%@ CPU · %@ GB RAM · %llu GB · %@%@" = "%@ CPU · %@ GB de RAM · %llu GB · %@%@";
@@ -99,6 +98,7 @@
 "Force Shut Down" = "Forzar apagado";
 "Force Shut Down Virtual Mac?" = "¿Forzar el apagado de Virtual Mac?";
 "Full Screen" = "Pantalla completa";
+"Fullscreen Mirroring" = "Fullscreen Mirroring";
 "General" = "General";
 "Get Help" = "Obtener ayuda";
 "Height" = "Altura";

--- a/VirtualMac/resources/Localizations/fi.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/fi.lproj/Localizable.strings
@@ -98,7 +98,7 @@
 "Force Shut Down" = "Pakota sammutus";
 "Force Shut Down Virtual Mac?" = "Pakotetaanko virtuaalisen Macin sammutus?";
 "Full Screen" = "Koko näyttö";
-"Fullscreen Mirroring" = "Fullscreen Mirroring";
+"Fullscreen Mirroring" = "Koko Näytön Peilaus";
 "General" = "Yleiset";
 "Get Help" = "Ohje";
 "Height" = "Korkeus";

--- a/VirtualMac/resources/Localizations/fi.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/fi.lproj/Localizable.strings
@@ -1,4 +1,3 @@
-/* Virtual Mac 1.1.1 localization. */
 " · Legacy" = " · Vanha";
 "%.0f%% complete" = "%.0f %% valmis";
 "%@ CPU · %@ GB RAM · %llu GB · %@%@" = "%@ CPU · %@ Gt RAM · %llu Gt · %@%@";
@@ -99,6 +98,7 @@
 "Force Shut Down" = "Pakota sammutus";
 "Force Shut Down Virtual Mac?" = "Pakotetaanko virtuaalisen Macin sammutus?";
 "Full Screen" = "Koko näyttö";
+"Fullscreen Mirroring" = "Fullscreen Mirroring";
 "General" = "Yleiset";
 "Get Help" = "Ohje";
 "Height" = "Korkeus";

--- a/VirtualMac/resources/Localizations/fr.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/fr.lproj/Localizable.strings
@@ -98,7 +98,7 @@
 "Force Shut Down" = "Forcer l’arrêt";
 "Force Shut Down Virtual Mac?" = "Forcer l’arrêt du Mac virtuel ?";
 "Full Screen" = "Plein écran";
-"Fullscreen Mirroring" = "Fullscreen Mirroring";
+"Fullscreen Mirroring" = "Mise en Miroir Plein Écran";
 "General" = "Général";
 "Get Help" = "Obtenir de l’aide";
 "Height" = "Hauteur";

--- a/VirtualMac/resources/Localizations/fr.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/fr.lproj/Localizable.strings
@@ -1,4 +1,3 @@
-/* Virtual Mac 1.1.1 localization. */
 " · Legacy" = " · Ancien";
 "%.0f%% complete" = "%.0f %% terminé";
 "%@ CPU · %@ GB RAM · %llu GB · %@%@" = "%@ CPU · %@ Go de RAM · %llu Go · %@%@";
@@ -99,6 +98,7 @@
 "Force Shut Down" = "Forcer l’arrêt";
 "Force Shut Down Virtual Mac?" = "Forcer l’arrêt du Mac virtuel ?";
 "Full Screen" = "Plein écran";
+"Fullscreen Mirroring" = "Fullscreen Mirroring";
 "General" = "Général";
 "Get Help" = "Obtenir de l’aide";
 "Height" = "Hauteur";

--- a/VirtualMac/resources/Localizations/fr_CA.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/fr_CA.lproj/Localizable.strings
@@ -98,7 +98,7 @@
 "Force Shut Down" = "Forcer l’arrêt";
 "Force Shut Down Virtual Mac?" = "Forcer l’arrêt du Mac virtuel ?";
 "Full Screen" = "Plein écran";
-"Fullscreen Mirroring" = "Fullscreen Mirroring";
+"Fullscreen Mirroring" = "Mise en Miroir Plein Écran";
 "General" = "Général";
 "Get Help" = "Obtenir de l’aide";
 "Height" = "Hauteur";

--- a/VirtualMac/resources/Localizations/fr_CA.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/fr_CA.lproj/Localizable.strings
@@ -1,4 +1,3 @@
-/* Virtual Mac 1.1.1 localization. */
 " · Legacy" = " · Ancien";
 "%.0f%% complete" = "%.0f %% terminé";
 "%@ CPU · %@ GB RAM · %llu GB · %@%@" = "%@ CPU · %@ Go de RAM · %llu Go · %@%@";
@@ -99,6 +98,7 @@
 "Force Shut Down" = "Forcer l’arrêt";
 "Force Shut Down Virtual Mac?" = "Forcer l’arrêt du Mac virtuel ?";
 "Full Screen" = "Plein écran";
+"Fullscreen Mirroring" = "Fullscreen Mirroring";
 "General" = "Général";
 "Get Help" = "Obtenir de l’aide";
 "Height" = "Hauteur";

--- a/VirtualMac/resources/Localizations/he.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/he.lproj/Localizable.strings
@@ -1,4 +1,3 @@
-/* Virtual Mac 1.1.1 localization. */
 " · Legacy" = " · ישן";
 "%.0f%% complete" = "%.0f%% הושלמו";
 "%@ CPU · %@ GB RAM · %llu GB · %@%@" = "%@ CPU · %@ GB RAM · %llu GB · %@%@";
@@ -99,6 +98,7 @@
 "Force Shut Down" = "אילוץ כיבוי";
 "Force Shut Down Virtual Mac?" = "לאלץ כיבוי של ה-Mac הווירטואלי?";
 "Full Screen" = "מסך מלא";
+"Fullscreen Mirroring" = "Fullscreen Mirroring";
 "General" = "כללי";
 "Get Help" = "קבלת עזרה";
 "Height" = "גובה";

--- a/VirtualMac/resources/Localizations/he.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/he.lproj/Localizable.strings
@@ -98,7 +98,7 @@
 "Force Shut Down" = "אילוץ כיבוי";
 "Force Shut Down Virtual Mac?" = "לאלץ כיבוי של ה-Mac הווירטואלי?";
 "Full Screen" = "מסך מלא";
-"Fullscreen Mirroring" = "Fullscreen Mirroring";
+"Fullscreen Mirroring" = "שיקוף במסך מלא";
 "General" = "כללי";
 "Get Help" = "קבלת עזרה";
 "Height" = "גובה";

--- a/VirtualMac/resources/Localizations/hi.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/hi.lproj/Localizable.strings
@@ -1,4 +1,3 @@
-/* Virtual Mac 1.1.1 localization. */
 " · Legacy" = " · पुराना";
 "%.0f%% complete" = "%.0f%% पूर्ण";
 "%@ CPU · %@ GB RAM · %llu GB · %@%@" = "%@ CPU · %@ GB RAM · %llu GB · %@%@";
@@ -99,6 +98,7 @@
 "Force Shut Down" = "ज़बरदस्ती बंद करें";
 "Force Shut Down Virtual Mac?" = "वर्चुअल Mac को ज़बरदस्ती बंद करें?";
 "Full Screen" = "पूर्ण स्क्रीन";
+"Fullscreen Mirroring" = "Fullscreen Mirroring";
 "General" = "सामान्य";
 "Get Help" = "सहायता पाएँ";
 "Height" = "ऊँचाई";

--- a/VirtualMac/resources/Localizations/hi.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/hi.lproj/Localizable.strings
@@ -98,7 +98,7 @@
 "Force Shut Down" = "ज़बरदस्ती बंद करें";
 "Force Shut Down Virtual Mac?" = "वर्चुअल Mac को ज़बरदस्ती बंद करें?";
 "Full Screen" = "पूर्ण स्क्रीन";
-"Fullscreen Mirroring" = "Fullscreen Mirroring";
+"Fullscreen Mirroring" = "पूर्ण स्क्रीन मिररिंग";
 "General" = "सामान्य";
 "Get Help" = "सहायता पाएँ";
 "Height" = "ऊँचाई";

--- a/VirtualMac/resources/Localizations/hr.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/hr.lproj/Localizable.strings
@@ -98,7 +98,7 @@
 "Force Shut Down" = "Prisilno isključi";
 "Force Shut Down Virtual Mac?" = "Prisilno isključiti Virtualni Mac?";
 "Full Screen" = "Cijeli zaslon";
-"Fullscreen Mirroring" = "Fullscreen Mirroring";
+"Fullscreen Mirroring" = "Potpuno Zrcaljenje Zaslona";
 "General" = "Općenito";
 "Get Help" = "Pomoć";
 "Height" = "Visina";

--- a/VirtualMac/resources/Localizations/hr.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/hr.lproj/Localizable.strings
@@ -1,4 +1,3 @@
-/* Virtual Mac 1.1.1 localization. */
 " · Legacy" = " · Starije";
 "%.0f%% complete" = "Dovršeno %.0f%%";
 "%@ CPU · %@ GB RAM · %llu GB · %@%@" = "%@ CPU · %@ GB RAM-a · %llu GB · %@%@";
@@ -99,6 +98,7 @@
 "Force Shut Down" = "Prisilno isključi";
 "Force Shut Down Virtual Mac?" = "Prisilno isključiti Virtualni Mac?";
 "Full Screen" = "Cijeli zaslon";
+"Fullscreen Mirroring" = "Fullscreen Mirroring";
 "General" = "Općenito";
 "Get Help" = "Pomoć";
 "Height" = "Visina";

--- a/VirtualMac/resources/Localizations/hu.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/hu.lproj/Localizable.strings
@@ -1,4 +1,3 @@
-/* Virtual Mac 1.1.1 localization. */
 " · Legacy" = " · Régi";
 "%.0f%% complete" = "%.0f%% kész";
 "%@ CPU · %@ GB RAM · %llu GB · %@%@" = "%@ CPU · %@ GB RAM · %llu GB · %@%@";
@@ -99,6 +98,7 @@
 "Force Shut Down" = "Kényszerített leállítás";
 "Force Shut Down Virtual Mac?" = "Kényszeríti a virtuális Mac leállítását?";
 "Full Screen" = "Teljes képernyő";
+"Fullscreen Mirroring" = "Fullscreen Mirroring";
 "General" = "Általános";
 "Get Help" = "Súgó";
 "Height" = "Magasság";

--- a/VirtualMac/resources/Localizations/hu.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/hu.lproj/Localizable.strings
@@ -98,7 +98,7 @@
 "Force Shut Down" = "Kényszerített leállítás";
 "Force Shut Down Virtual Mac?" = "Kényszeríti a virtuális Mac leállítását?";
 "Full Screen" = "Teljes képernyő";
-"Fullscreen Mirroring" = "Fullscreen Mirroring";
+"Fullscreen Mirroring" = "Teljes Képernyős Tükrözés";
 "General" = "Általános";
 "Get Help" = "Súgó";
 "Height" = "Magasság";

--- a/VirtualMac/resources/Localizations/id.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/id.lproj/Localizable.strings
@@ -98,7 +98,7 @@
 "Force Shut Down" = "Paksa Matikan";
 "Force Shut Down Virtual Mac?" = "Paksa Matikan Virtual Mac?";
 "Full Screen" = "Layar Penuh";
-"Fullscreen Mirroring" = "Fullscreen Mirroring";
+"Fullscreen Mirroring" = "Pencerminan Layar Penuh";
 "General" = "Umum";
 "Get Help" = "Dapatkan Bantuan";
 "Height" = "Tinggi";

--- a/VirtualMac/resources/Localizations/id.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/id.lproj/Localizable.strings
@@ -1,4 +1,3 @@
-/* Virtual Mac 1.1.1 localization. */
 " · Legacy" = " · Lama";
 "%.0f%% complete" = "%.0f%% selesai";
 "%@ CPU · %@ GB RAM · %llu GB · %@%@" = "%@ CPU · RAM %@ GB · %llu GB · %@%@";
@@ -99,6 +98,7 @@
 "Force Shut Down" = "Paksa Matikan";
 "Force Shut Down Virtual Mac?" = "Paksa Matikan Virtual Mac?";
 "Full Screen" = "Layar Penuh";
+"Fullscreen Mirroring" = "Fullscreen Mirroring";
 "General" = "Umum";
 "Get Help" = "Dapatkan Bantuan";
 "Height" = "Tinggi";

--- a/VirtualMac/resources/Localizations/it.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/it.lproj/Localizable.strings
@@ -1,4 +1,3 @@
-/* Virtual Mac 1.1.1 localization. */
 " · Legacy" = " · Versione precedente";
 "%.0f%% complete" = "%.0f%% completato";
 "%@ CPU · %@ GB RAM · %llu GB · %@%@" = "%@ CPU · %@ GB di RAM · %llu GB · %@%@";
@@ -99,6 +98,7 @@
 "Force Shut Down" = "Forza spegnimento";
 "Force Shut Down Virtual Mac?" = "Forzare lo spegnimento di Virtual Mac?";
 "Full Screen" = "Schermo intero";
+"Fullscreen Mirroring" = "Fullscreen Mirroring";
 "General" = "Generali";
 "Get Help" = "Ottieni assistenza";
 "Height" = "Altezza";

--- a/VirtualMac/resources/Localizations/it.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/it.lproj/Localizable.strings
@@ -98,7 +98,7 @@
 "Force Shut Down" = "Forza spegnimento";
 "Force Shut Down Virtual Mac?" = "Forzare lo spegnimento di Virtual Mac?";
 "Full Screen" = "Schermo intero";
-"Fullscreen Mirroring" = "Fullscreen Mirroring";
+"Fullscreen Mirroring" = "Mirroring a Schermo Intero";
 "General" = "Generali";
 "Get Help" = "Ottieni assistenza";
 "Height" = "Altezza";

--- a/VirtualMac/resources/Localizations/ja.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/ja.lproj/Localizable.strings
@@ -1,4 +1,3 @@
-/* Virtual Mac 1.1.1 localization. */
 " · Legacy" = " · レガシー";
 "%.0f%% complete" = "%.0f%%完了";
 "%@ CPU · %@ GB RAM · %llu GB · %@%@" = "%@ CPU · %@ GB RAM · %llu GB · %@%@";
@@ -99,6 +98,7 @@
 "Force Shut Down" = "強制終了";
 "Force Shut Down Virtual Mac?" = "仮想Macを強制終了しますか？";
 "Full Screen" = "フルスクリーン";
+"Fullscreen Mirroring" = "Fullscreen Mirroring";
 "General" = "一般";
 "Get Help" = "ヘルプを表示";
 "Height" = "高さ";

--- a/VirtualMac/resources/Localizations/ja.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/ja.lproj/Localizable.strings
@@ -98,7 +98,7 @@
 "Force Shut Down" = "強制終了";
 "Force Shut Down Virtual Mac?" = "仮想Macを強制終了しますか？";
 "Full Screen" = "フルスクリーン";
-"Fullscreen Mirroring" = "Fullscreen Mirroring";
+"Fullscreen Mirroring" = "フルスクリーンミラーリング";
 "General" = "一般";
 "Get Help" = "ヘルプを表示";
 "Height" = "高さ";

--- a/VirtualMac/resources/Localizations/ko.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/ko.lproj/Localizable.strings
@@ -1,4 +1,3 @@
-/* Virtual Mac 1.1.1 localization. */
 " · Legacy" = " · 레거시";
 "%.0f%% complete" = "%.0f%% 완료";
 "%@ CPU · %@ GB RAM · %llu GB · %@%@" = "%@ CPU · %@GB RAM · %lluGB · %@%@";
@@ -99,6 +98,7 @@
 "Force Shut Down" = "강제 종료";
 "Force Shut Down Virtual Mac?" = "가상 Mac을 강제로 종료하시겠습니까?";
 "Full Screen" = "전체 화면";
+"Fullscreen Mirroring" = "Fullscreen Mirroring";
 "General" = "일반";
 "Get Help" = "도움말 보기";
 "Height" = "높이";

--- a/VirtualMac/resources/Localizations/ko.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/ko.lproj/Localizable.strings
@@ -98,7 +98,7 @@
 "Force Shut Down" = "강제 종료";
 "Force Shut Down Virtual Mac?" = "가상 Mac을 강제로 종료하시겠습니까?";
 "Full Screen" = "전체 화면";
-"Fullscreen Mirroring" = "Fullscreen Mirroring";
+"Fullscreen Mirroring" = "전체 화면 미러링";
 "General" = "일반";
 "Get Help" = "도움말 보기";
 "Height" = "높이";

--- a/VirtualMac/resources/Localizations/ms.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/ms.lproj/Localizable.strings
@@ -98,7 +98,7 @@
 "Force Shut Down" = "Paksa Matikan";
 "Force Shut Down Virtual Mac?" = "Paksa Matikan Mac maya?";
 "Full Screen" = "Skrin Penuh";
-"Fullscreen Mirroring" = "Fullscreen Mirroring";
+"Fullscreen Mirroring" = "Pencerminan Skrin Penuh";
 "General" = "Umum";
 "Get Help" = "Dapatkan Bantuan";
 "Height" = "Ketinggian";

--- a/VirtualMac/resources/Localizations/ms.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/ms.lproj/Localizable.strings
@@ -1,4 +1,3 @@
-/* Virtual Mac 1.1.1 localization. */
 " · Legacy" = " · Lama";
 "%.0f%% complete" = "%.0f%% selesai";
 "%@ CPU · %@ GB RAM · %llu GB · %@%@" = "%@ CPU · RAM %@ GB · %llu GB · %@%@";
@@ -99,6 +98,7 @@
 "Force Shut Down" = "Paksa Matikan";
 "Force Shut Down Virtual Mac?" = "Paksa Matikan Mac maya?";
 "Full Screen" = "Skrin Penuh";
+"Fullscreen Mirroring" = "Fullscreen Mirroring";
 "General" = "Umum";
 "Get Help" = "Dapatkan Bantuan";
 "Height" = "Ketinggian";

--- a/VirtualMac/resources/Localizations/nl.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/nl.lproj/Localizable.strings
@@ -1,4 +1,3 @@
-/* Virtual Mac 1.1.1 localization. */
 " · Legacy" = " · Verouderd";
 "%.0f%% complete" = "%.0f%% voltooid";
 "%@ CPU · %@ GB RAM · %llu GB · %@%@" = "%@ CPU · %@ GB RAM · %llu GB · %@%@";
@@ -99,6 +98,7 @@
 "Force Shut Down" = "Forceer uitschakelen";
 "Force Shut Down Virtual Mac?" = "Uitschakelen van Virtual Mac forceren?";
 "Full Screen" = "Volledig scherm";
+"Fullscreen Mirroring" = "Fullscreen Mirroring";
 "General" = "Algemeen";
 "Get Help" = "Hulp";
 "Height" = "Hoogte";

--- a/VirtualMac/resources/Localizations/nl.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/nl.lproj/Localizable.strings
@@ -98,7 +98,7 @@
 "Force Shut Down" = "Forceer uitschakelen";
 "Force Shut Down Virtual Mac?" = "Uitschakelen van Virtual Mac forceren?";
 "Full Screen" = "Volledig scherm";
-"Fullscreen Mirroring" = "Fullscreen Mirroring";
+"Fullscreen Mirroring" = "Volledige Schermspiegeling";
 "General" = "Algemeen";
 "Get Help" = "Hulp";
 "Height" = "Hoogte";

--- a/VirtualMac/resources/Localizations/no.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/no.lproj/Localizable.strings
@@ -98,7 +98,7 @@
 "Force Shut Down" = "Tving avslutning";
 "Force Shut Down Virtual Mac?" = "Tving avslutning av Virtual Mac?";
 "Full Screen" = "Fullskjerm";
-"Fullscreen Mirroring" = "Fullscreen Mirroring";
+"Fullscreen Mirroring" = "Fullskjermsspeiling";
 "General" = "Generelt";
 "Get Help" = "Få hjelp";
 "Height" = "Høyde";

--- a/VirtualMac/resources/Localizations/no.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/no.lproj/Localizable.strings
@@ -1,4 +1,3 @@
-/* Virtual Mac 1.1.1 localization. */
 " · Legacy" = " · Eldre";
 "%.0f%% complete" = "%.0f%% fullført";
 "%@ CPU · %@ GB RAM · %llu GB · %@%@" = "%@ CPU · %@ GB RAM · %llu GB · %@%@";
@@ -99,6 +98,7 @@
 "Force Shut Down" = "Tving avslutning";
 "Force Shut Down Virtual Mac?" = "Tving avslutning av Virtual Mac?";
 "Full Screen" = "Fullskjerm";
+"Fullscreen Mirroring" = "Fullscreen Mirroring";
 "General" = "Generelt";
 "Get Help" = "Få hjelp";
 "Height" = "Høyde";

--- a/VirtualMac/resources/Localizations/pl.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/pl.lproj/Localizable.strings
@@ -98,7 +98,7 @@
 "Force Shut Down" = "Wymuś wyłączenie";
 "Force Shut Down Virtual Mac?" = "Wymusić wyłączenie Virtual Maca?";
 "Full Screen" = "Pełny ekran";
-"Fullscreen Mirroring" = "Fullscreen Mirroring";
+"Fullscreen Mirroring" = "Kopiowanie Pełnoekranowe";
 "General" = "Ogólne";
 "Get Help" = "Pomoc";
 "Height" = "Wysokość";

--- a/VirtualMac/resources/Localizations/pl.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/pl.lproj/Localizable.strings
@@ -1,4 +1,3 @@
-/* Virtual Mac 1.1.1 localization. */
 " · Legacy" = " · Starsze";
 "%.0f%% complete" = "Ukończono %.0f%%";
 "%@ CPU · %@ GB RAM · %llu GB · %@%@" = "%@ CPU · %@ GB RAM · %llu GB · %@%@";
@@ -99,6 +98,7 @@
 "Force Shut Down" = "Wymuś wyłączenie";
 "Force Shut Down Virtual Mac?" = "Wymusić wyłączenie Virtual Maca?";
 "Full Screen" = "Pełny ekran";
+"Fullscreen Mirroring" = "Fullscreen Mirroring";
 "General" = "Ogólne";
 "Get Help" = "Pomoc";
 "Height" = "Wysokość";

--- a/VirtualMac/resources/Localizations/pt.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/pt.lproj/Localizable.strings
@@ -98,7 +98,7 @@
 "Force Shut Down" = "Forçar desligamento";
 "Force Shut Down Virtual Mac?" = "Forçar o desligamento do Virtual Mac?";
 "Full Screen" = "Tela cheia";
-"Fullscreen Mirroring" = "Fullscreen Mirroring";
+"Fullscreen Mirroring" = "Espelhamento em Tela Cheia";
 "General" = "Geral";
 "Get Help" = "Obter ajuda";
 "Height" = "Altura";

--- a/VirtualMac/resources/Localizations/pt.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/pt.lproj/Localizable.strings
@@ -1,4 +1,3 @@
-/* Virtual Mac 1.1.1 localization. */
 " · Legacy" = " · Legado";
 "%.0f%% complete" = "%.0f%% concluído";
 "%@ CPU · %@ GB RAM · %llu GB · %@%@" = "%@ CPU · %@ GB de RAM · %llu GB · %@%@";
@@ -99,6 +98,7 @@
 "Force Shut Down" = "Forçar desligamento";
 "Force Shut Down Virtual Mac?" = "Forçar o desligamento do Virtual Mac?";
 "Full Screen" = "Tela cheia";
+"Fullscreen Mirroring" = "Fullscreen Mirroring";
 "General" = "Geral";
 "Get Help" = "Obter ajuda";
 "Height" = "Altura";

--- a/VirtualMac/resources/Localizations/pt_PT.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/pt_PT.lproj/Localizable.strings
@@ -1,4 +1,3 @@
-/* Virtual Mac 1.1.1 localization. */
 " · Legacy" = " · Legado";
 "%.0f%% complete" = "%.0f%% concluído";
 "%@ CPU · %@ GB RAM · %llu GB · %@%@" = "%@ CPU · %@ GB de RAM · %llu GB · %@%@";
@@ -99,6 +98,7 @@
 "Force Shut Down" = "Forçar desligamento";
 "Force Shut Down Virtual Mac?" = "Forçar o desligamento do Virtual Mac?";
 "Full Screen" = "Ecrã inteiro";
+"Fullscreen Mirroring" = "Fullscreen Mirroring";
 "General" = "Geral";
 "Get Help" = "Obter ajuda";
 "Height" = "Altura";

--- a/VirtualMac/resources/Localizations/pt_PT.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/pt_PT.lproj/Localizable.strings
@@ -98,7 +98,7 @@
 "Force Shut Down" = "Forçar desligamento";
 "Force Shut Down Virtual Mac?" = "Forçar o desligamento do Virtual Mac?";
 "Full Screen" = "Ecrã inteiro";
-"Fullscreen Mirroring" = "Fullscreen Mirroring";
+"Fullscreen Mirroring" = "Espelhamento em Ecrã Inteiro";
 "General" = "Geral";
 "Get Help" = "Obter ajuda";
 "Height" = "Altura";

--- a/VirtualMac/resources/Localizations/ro.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/ro.lproj/Localizable.strings
@@ -1,4 +1,3 @@
-/* Virtual Mac 1.1.1 localization. */
 " · Legacy" = " · Versiune veche";
 "%.0f%% complete" = "%.0f%% finalizat";
 "%@ CPU · %@ GB RAM · %llu GB · %@%@" = "%@ CPU · %@ GB RAM · %llu GB · %@%@";
@@ -99,6 +98,7 @@
 "Force Shut Down" = "Forțați oprirea";
 "Force Shut Down Virtual Mac?" = "Forzare lo oprire di Mac virtual?";
 "Full Screen" = "Ecran complet";
+"Fullscreen Mirroring" = "Fullscreen Mirroring";
 "General" = "Generali";
 "Get Help" = "Obțineți ajutor";
 "Height" = "Înălțime";

--- a/VirtualMac/resources/Localizations/ro.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/ro.lproj/Localizable.strings
@@ -98,7 +98,7 @@
 "Force Shut Down" = "Forțați oprirea";
 "Force Shut Down Virtual Mac?" = "Forzare lo oprire di Mac virtual?";
 "Full Screen" = "Ecran complet";
-"Fullscreen Mirroring" = "Fullscreen Mirroring";
+"Fullscreen Mirroring" = "Oglindire pe Tot Ecranul";
 "General" = "Generali";
 "Get Help" = "Obțineți ajutor";
 "Height" = "Înălțime";

--- a/VirtualMac/resources/Localizations/ru.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/ru.lproj/Localizable.strings
@@ -1,4 +1,3 @@
-/* Virtual Mac 1.1.1 localization. */
 " · Legacy" = " · Устаревшая";
 "%.0f%% complete" = "Выполнено: %.0f%%";
 "%@ CPU · %@ GB RAM · %llu GB · %@%@" = "%@ ЦП · %@ ГБ ОЗУ · %llu ГБ · %@%@";
@@ -99,6 +98,7 @@
 "Force Shut Down" = "Принудительно выключить";
 "Force Shut Down Virtual Mac?" = "Принудительно выключить виртуальный Mac?";
 "Full Screen" = "Во весь экран";
+"Fullscreen Mirroring" = "Fullscreen Mirroring";
 "General" = "Основные";
 "Get Help" = "Справка";
 "Height" = "Высота";

--- a/VirtualMac/resources/Localizations/ru.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/ru.lproj/Localizable.strings
@@ -98,7 +98,7 @@
 "Force Shut Down" = "Принудительно выключить";
 "Force Shut Down Virtual Mac?" = "Принудительно выключить виртуальный Mac?";
 "Full Screen" = "Во весь экран";
-"Fullscreen Mirroring" = "Fullscreen Mirroring";
+"Fullscreen Mirroring" = "Полноэкранное Дублирование";
 "General" = "Основные";
 "Get Help" = "Справка";
 "Height" = "Высота";

--- a/VirtualMac/resources/Localizations/sk.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/sk.lproj/Localizable.strings
@@ -98,7 +98,7 @@
 "Force Shut Down" = "Vynutit vypnutí";
 "Force Shut Down Virtual Mac?" = "Vynutit vypnutí virtuálnyho Macu?";
 "Full Screen" = "Celá obrazovka";
-"Fullscreen Mirroring" = "Fullscreen Mirroring";
+"Fullscreen Mirroring" = "Celozrkadlenie Obrazovky";
 "General" = "Všeobecné";
 "Get Help" = "Pomoc";
 "Height" = "Výška";

--- a/VirtualMac/resources/Localizations/sk.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/sk.lproj/Localizable.strings
@@ -1,4 +1,3 @@
-/* Virtual Mac 1.1.1 localization. */
 " · Legacy" = " · Starší";
 "%.0f%% complete" = "%.0f %% dokončené";
 "%@ CPU · %@ GB RAM · %llu GB · %@%@" = "%@ CPU · %@ GB RAM · %llu GB · %@%@";
@@ -99,6 +98,7 @@
 "Force Shut Down" = "Vynutit vypnutí";
 "Force Shut Down Virtual Mac?" = "Vynutit vypnutí virtuálnyho Macu?";
 "Full Screen" = "Celá obrazovka";
+"Fullscreen Mirroring" = "Fullscreen Mirroring";
 "General" = "Všeobecné";
 "Get Help" = "Pomoc";
 "Height" = "Výška";

--- a/VirtualMac/resources/Localizations/sl.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/sl.lproj/Localizable.strings
@@ -98,7 +98,7 @@
 "Force Shut Down" = "Vsili zaustavitev";
 "Force Shut Down Virtual Mac?" = "Želite prisilno zaustaviti Virtual Mac?";
 "Full Screen" = "Celozaslonsko";
-"Fullscreen Mirroring" = "Fullscreen Mirroring";
+"Fullscreen Mirroring" = "Zrcaljenje Celotnega Zaslona";
 "General" = "Splošno";
 "Get Help" = "Pomoč";
 "Height" = "Višina";

--- a/VirtualMac/resources/Localizations/sl.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/sl.lproj/Localizable.strings
@@ -1,4 +1,3 @@
-/* Virtual Mac 1.1.1 localization. */
 " · Legacy" = " · Starejše";
 "%.0f%% complete" = "Dokončano %.0f%%";
 "%@ CPU · %@ GB RAM · %llu GB · %@%@" = "%@ CPE · %@ GB pomnilnika · %llu GB · %@%@";
@@ -99,6 +98,7 @@
 "Force Shut Down" = "Vsili zaustavitev";
 "Force Shut Down Virtual Mac?" = "Želite prisilno zaustaviti Virtual Mac?";
 "Full Screen" = "Celozaslonsko";
+"Fullscreen Mirroring" = "Fullscreen Mirroring";
 "General" = "Splošno";
 "Get Help" = "Pomoč";
 "Height" = "Višina";

--- a/VirtualMac/resources/Localizations/sv.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/sv.lproj/Localizable.strings
@@ -98,7 +98,7 @@
 "Force Shut Down" = "Tvinga avstängning";
 "Force Shut Down Virtual Mac?" = "Tvinga avstängning av Virtual Mac?";
 "Full Screen" = "Helskärm";
-"Fullscreen Mirroring" = "Fullscreen Mirroring";
+"Fullscreen Mirroring" = "Helskärmsspegling";
 "General" = "Allmänt";
 "Get Help" = "Få hjälp";
 "Height" = "Höjd";

--- a/VirtualMac/resources/Localizations/sv.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/sv.lproj/Localizable.strings
@@ -1,4 +1,3 @@
-/* Virtual Mac 1.1.1 localization. */
 " · Legacy" = " · Äldre";
 "%.0f%% complete" = "%.0f%% slutfört";
 "%@ CPU · %@ GB RAM · %llu GB · %@%@" = "%@ CPU · %@ GB RAM · %llu GB · %@%@";
@@ -99,6 +98,7 @@
 "Force Shut Down" = "Tvinga avstängning";
 "Force Shut Down Virtual Mac?" = "Tvinga avstängning av Virtual Mac?";
 "Full Screen" = "Helskärm";
+"Fullscreen Mirroring" = "Fullscreen Mirroring";
 "General" = "Allmänt";
 "Get Help" = "Få hjälp";
 "Height" = "Höjd";

--- a/VirtualMac/resources/Localizations/th.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/th.lproj/Localizable.strings
@@ -1,4 +1,3 @@
-/* Virtual Mac 1.1.1 localization. */
 " · Legacy" = " · รุ่นเก่า";
 "%.0f%% complete" = "เสร็จแล้ว %.0f%%";
 "%@ CPU · %@ GB RAM · %llu GB · %@%@" = "CPU %@ ตัว · หน่วยความจำ %@ GB · %llu GB · %@%@";
@@ -99,6 +98,7 @@
 "Force Shut Down" = "บังคับปิดเครื่อง";
 "Force Shut Down Virtual Mac?" = "บังคับปิด Virtual Mac หรือไม่";
 "Full Screen" = "เต็มหน้าจอ";
+"Fullscreen Mirroring" = "Fullscreen Mirroring";
 "General" = "ทั่วไป";
 "Get Help" = "ขอความช่วยเหลือ";
 "Height" = "ความสูง";

--- a/VirtualMac/resources/Localizations/th.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/th.lproj/Localizable.strings
@@ -98,7 +98,7 @@
 "Force Shut Down" = "บังคับปิดเครื่อง";
 "Force Shut Down Virtual Mac?" = "บังคับปิด Virtual Mac หรือไม่";
 "Full Screen" = "เต็มหน้าจอ";
-"Fullscreen Mirroring" = "Fullscreen Mirroring";
+"Fullscreen Mirroring" = "การสะท้อนภาพเต็มจอ";
 "General" = "ทั่วไป";
 "Get Help" = "ขอความช่วยเหลือ";
 "Height" = "ความสูง";

--- a/VirtualMac/resources/Localizations/tr.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/tr.lproj/Localizable.strings
@@ -98,7 +98,7 @@
 "Force Shut Down" = "Kapatmaya Zorla";
 "Force Shut Down Virtual Mac?" = "Sanal Mac Kapatmaya Zorlansın mı?";
 "Full Screen" = "Tam Ekran";
-"Fullscreen Mirroring" = "Fullscreen Mirroring";
+"Fullscreen Mirroring" = "Tam Ekran Yansıtma";
 "General" = "Genel";
 "Get Help" = "Yardım Al";
 "Height" = "Yükseklik";

--- a/VirtualMac/resources/Localizations/tr.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/tr.lproj/Localizable.strings
@@ -1,4 +1,3 @@
-/* Virtual Mac 1.1.1 localization. */
 " · Legacy" = " · Eski";
 "%.0f%% complete" = "%.0f%% tamamlandı";
 "%@ CPU · %@ GB RAM · %llu GB · %@%@" = "%@ CPU · %@ GB RAM · %llu GB · %@%@";
@@ -99,6 +98,7 @@
 "Force Shut Down" = "Kapatmaya Zorla";
 "Force Shut Down Virtual Mac?" = "Sanal Mac Kapatmaya Zorlansın mı?";
 "Full Screen" = "Tam Ekran";
+"Fullscreen Mirroring" = "Fullscreen Mirroring";
 "General" = "Genel";
 "Get Help" = "Yardım Al";
 "Height" = "Yükseklik";

--- a/VirtualMac/resources/Localizations/uk.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/uk.lproj/Localizable.strings
@@ -98,7 +98,7 @@
 "Force Shut Down" = "Принудительно вимкнути";
 "Force Shut Down Virtual Mac?" = "Принудительно вимкнути віртуальний Mac?";
 "Full Screen" = "На весь екран";
-"Fullscreen Mirroring" = "Fullscreen Mirroring";
+"Fullscreen Mirroring" = "Повноекранне Дзеркалення";
 "General" = "Загальні";
 "Get Help" = "Довідка";
 "Height" = "Висота";

--- a/VirtualMac/resources/Localizations/uk.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/uk.lproj/Localizable.strings
@@ -1,4 +1,3 @@
-/* Virtual Mac 1.1.1 localization. */
 " · Legacy" = " · Устаревшая";
 "%.0f%% complete" = "Виконано %.0f%%";
 "%@ CPU · %@ GB RAM · %llu GB · %@%@" = "%@ ЦП · %@ ГБ ОЗУ · %llu ГБ · %@%@";
@@ -99,6 +98,7 @@
 "Force Shut Down" = "Принудительно вимкнути";
 "Force Shut Down Virtual Mac?" = "Принудительно вимкнути віртуальний Mac?";
 "Full Screen" = "На весь екран";
+"Fullscreen Mirroring" = "Fullscreen Mirroring";
 "General" = "Загальні";
 "Get Help" = "Довідка";
 "Height" = "Висота";

--- a/VirtualMac/resources/Localizations/vi.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/vi.lproj/Localizable.strings
@@ -1,4 +1,3 @@
-/* Virtual Mac 1.1.1 localization. */
 " · Legacy" = " · Cũ";
 "%.0f%% complete" = "Đã hoàn tất %.0f%%";
 "%@ CPU · %@ GB RAM · %llu GB · %@%@" = "%@ CPU · %@ GB RAM · %llu GB · %@%@";
@@ -99,6 +98,7 @@
 "Force Shut Down" = "Buộc tắt";
 "Force Shut Down Virtual Mac?" = "Buộc tắt máy Mac ảo?";
 "Full Screen" = "Toàn màn hình";
+"Fullscreen Mirroring" = "Fullscreen Mirroring";
 "General" = "Cài đặt chung";
 "Get Help" = "Nhận trợ giúp";
 "Height" = "Chiều cao";

--- a/VirtualMac/resources/Localizations/vi.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/vi.lproj/Localizable.strings
@@ -98,7 +98,7 @@
 "Force Shut Down" = "Buộc tắt";
 "Force Shut Down Virtual Mac?" = "Buộc tắt máy Mac ảo?";
 "Full Screen" = "Toàn màn hình";
-"Fullscreen Mirroring" = "Fullscreen Mirroring";
+"Fullscreen Mirroring" = "Phản Chiếu Toàn Màn Hình";
 "General" = "Cài đặt chung";
 "Get Help" = "Nhận trợ giúp";
 "Height" = "Chiều cao";

--- a/VirtualMac/resources/Localizations/zh_CN.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/zh_CN.lproj/Localizable.strings
@@ -1,4 +1,3 @@
-/* Virtual Mac 1.1.1 localization. */
 " · Legacy" = " · 旧版";
 "%.0f%% complete" = "已完成%.0f%%";
 "%@ CPU · %@ GB RAM · %llu GB · %@%@" = "%@核CPU · %@ GB内存 · %llu GB · %@%@";
@@ -99,6 +98,7 @@
 "Force Shut Down" = "强制关机";
 "Force Shut Down Virtual Mac?" = "要强制关闭虚拟Mac吗？";
 "Full Screen" = "全屏";
+"Fullscreen Mirroring" = "Fullscreen Mirroring";
 "General" = "通用";
 "Get Help" = "获取帮助";
 "Height" = "高度";

--- a/VirtualMac/resources/Localizations/zh_CN.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/zh_CN.lproj/Localizable.strings
@@ -98,7 +98,7 @@
 "Force Shut Down" = "强制关机";
 "Force Shut Down Virtual Mac?" = "要强制关闭虚拟Mac吗？";
 "Full Screen" = "全屏";
-"Fullscreen Mirroring" = "Fullscreen Mirroring";
+"Fullscreen Mirroring" = "全屏幕镜像";
 "General" = "通用";
 "Get Help" = "获取帮助";
 "Height" = "高度";

--- a/VirtualMac/resources/Localizations/zh_HK.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/zh_HK.lproj/Localizable.strings
@@ -1,4 +1,3 @@
-/* Virtual Mac 1.1.1 localization. */
 " · Legacy" = " · 舊版";
 "%.0f%% complete" = "已完成%.0f%%";
 "%@ CPU · %@ GB RAM · %llu GB · %@%@" = "%@核CPU · %@ GB內存 · %llu GB · %@%@";
@@ -99,6 +98,7 @@
 "Force Shut Down" = "強制關機";
 "Force Shut Down Virtual Mac?" = "要強制關閉虛擬Mac嗎？";
 "Full Screen" = "全螢幕";
+"Fullscreen Mirroring" = "Fullscreen Mirroring";
 "General" = "一般";
 "Get Help" = "取得協助";
 "Height" = "高度";

--- a/VirtualMac/resources/Localizations/zh_HK.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/zh_HK.lproj/Localizable.strings
@@ -98,7 +98,7 @@
 "Force Shut Down" = "強制關機";
 "Force Shut Down Virtual Mac?" = "要強制關閉虛擬Mac嗎？";
 "Full Screen" = "全螢幕";
-"Fullscreen Mirroring" = "Fullscreen Mirroring";
+"Fullscreen Mirroring" = "全螢幕鏡像";
 "General" = "一般";
 "Get Help" = "取得協助";
 "Height" = "高度";

--- a/VirtualMac/resources/Localizations/zh_TW.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/zh_TW.lproj/Localizable.strings
@@ -1,4 +1,3 @@
-/* Virtual Mac 1.1.1 localization. */
 " · Legacy" = " · 舊版";
 "%.0f%% complete" = "已完成%.0f%%";
 "%@ CPU · %@ GB RAM · %llu GB · %@%@" = "%@核CPU · %@ GB記憶體 · %llu GB · %@%@";
@@ -99,6 +98,7 @@
 "Force Shut Down" = "強制關機";
 "Force Shut Down Virtual Mac?" = "要強制關閉虛擬Mac嗎？";
 "Full Screen" = "全螢幕";
+"Fullscreen Mirroring" = "Fullscreen Mirroring";
 "General" = "一般";
 "Get Help" = "取得協助";
 "Height" = "高度";

--- a/VirtualMac/resources/Localizations/zh_TW.lproj/Localizable.strings
+++ b/VirtualMac/resources/Localizations/zh_TW.lproj/Localizable.strings
@@ -98,7 +98,7 @@
 "Force Shut Down" = "強制關機";
 "Force Shut Down Virtual Mac?" = "要強制關閉虛擬Mac嗎？";
 "Full Screen" = "全螢幕";
-"Fullscreen Mirroring" = "Fullscreen Mirroring";
+"Fullscreen Mirroring" = "全螢幕鏡像";
 "General" = "一般";
 "Get Help" = "取得協助";
 "Height" = "高度";

--- a/VirtualMac/scripts/validate-localizations.py
+++ b/VirtualMac/scripts/validate-localizations.py
@@ -30,6 +30,7 @@ TECHNICAL_IDENTICAL_VALUES = {
     "%@ CPU · %@ GB RAM · %llu GB · %@%@",
     "Build %@ · %@ · %@",
     "Ethernet (%@)",
+    "Fullscreen Mirroring",
     "MAC Address",
     "Mac Keyboard",
     "Mac Trackpad",

--- a/VirtualMac/vz/host/VZAppSettings.h
+++ b/VirtualMac/vz/host/VZAppSettings.h
@@ -14,6 +14,7 @@ FOUNDATION_EXPORT NSString * const VZShowStatusLabelKey;
 FOUNDATION_EXPORT NSString * const VZAutoDeleteRestoreImageKey;
 FOUNDATION_EXPORT NSString * const VZHUDVisibilityKey;
 FOUNDATION_EXPORT NSString * const VZHUDCornerKey;
+FOUNDATION_EXPORT NSString * const VZExternalDisplayEnabledKey;
 FOUNDATION_EXPORT NSString * const VZDisplayScalingKey;
 FOUNDATION_EXPORT NSString * const VZTouchDoubleTapAccommodationKey;
 FOUNDATION_EXPORT NSString * const VZTouchTwoFingerScrollingKey;

--- a/VirtualMac/vz/host/VZAppSettings.m
+++ b/VirtualMac/vz/host/VZAppSettings.m
@@ -12,6 +12,7 @@ NSString * const VZShowStatusLabelKey = @"ShowDebugStatusOverlay";
 NSString * const VZAutoDeleteRestoreImageKey = @"AutoDeleteRestoreImage";
 NSString * const VZHUDVisibilityKey = @"HUDVisibility";
 NSString * const VZHUDCornerKey = @"HUDCorner";
+NSString * const VZExternalDisplayEnabledKey = @"ExternalDisplayEnabled";
 NSString * const VZDisplayScalingKey = @"DisplayScaling";
 NSString * const VZTouchDoubleTapAccommodationKey = @"TouchDoubleTapAccommodation";
 NSString * const VZTouchTwoFingerScrollingKey = @"TouchTwoFingerScrolling";
@@ -62,6 +63,7 @@ static CFStringRef const VZSettingsDarwinNotification =
         VZAutoDeleteRestoreImageKey: @YES,
         VZHUDVisibilityKey: @"automatic",
         VZHUDCornerKey: @"top-right",
+        VZExternalDisplayEnabledKey: @NO,
         VZDisplayScalingKey: @"fit",
         VZTouchDoubleTapAccommodationKey: @YES,
         VZTouchTwoFingerScrollingKey: @YES,

--- a/VirtualMac/vz/host/VirtualMacApp.m
+++ b/VirtualMac/vz/host/VirtualMacApp.m
@@ -94,6 +94,7 @@ static void setStatus(NSString *status);
 // External display (Keynote-style: UIWindow.screen = externalScreen)
 static UIWindow *gExternalWindow;
 static UIView *gExternalMirrorView;
+static UIImageView *gExternalCursorView;
 
 static void updateDisplayGeometry(void);
 static void logFramebufferState(id view, id framebuffer, const char *phase);
@@ -2969,6 +2970,28 @@ static void updateCursorOverlay(VZFrameUpdateSharedPtr update) {
         // update reconciles it without the cursor jumping one frame backward.
         if (CACurrentMediaTime() - gLastPredictedCursorTime >= 0.05)
             gCursorView.frame = (CGRect){origin, size};
+        // Mirror cursor to external display if connected.
+        if (gExternalCursorView) {
+            CGRect viewport = aspectFitRect(gDisplayPixelSize,
+                                            gExternalWindow.bounds);
+            CGFloat extScaleX = viewport.size.width /
+                                gDisplayPixelSize.width;
+            CGFloat extScaleY = viewport.size.height /
+                                gDisplayPixelSize.height;
+            CGSize extSize = CGSizeMake(
+                gCursorPixelSize.width * extScaleX,
+                gCursorPixelSize.height * extScaleY);
+            CGPoint extOrigin = CGPointMake(
+                viewport.origin.x +
+                    ((CGFloat)guestX - gCursorHotspot.x) * extScaleX,
+                viewport.origin.y +
+                    ((CGFloat)guestY - gCursorHotspot.y) * extScaleY);
+            if (imageChanged) {
+                gExternalCursorView.image = gCursorView.image;
+                gExternalCursorView.hidden = gCursorView.hidden;
+            }
+            gExternalCursorView.frame = (CGRect){extOrigin, extSize};
+        }
         [image release];
     });
 }
@@ -3909,6 +3932,11 @@ static void connectExternalDisplay(void) {
     gExternalMirrorView = mirrorView;
     [mirrorView release];
 
+    gExternalCursorView = [[UIImageView alloc] initWithFrame:CGRectZero];
+    gExternalCursorView.backgroundColor = [UIColor clearColor];
+    gExternalCursorView.contentMode = UIViewContentModeScaleToFill;
+    [gExternalWindow addSubview:gExternalCursorView];
+
     gExternalWindow.hidden = NO;
     printf("[VirtualMac] external window created frame=%s\n",
            NSStringFromCGRect(gExternalWindow.frame).UTF8String);
@@ -3919,6 +3947,9 @@ static void disconnectExternalDisplay(void) {
         return;
     printf("[VirtualMac] external display disconnecting\n");
     gExternalMirrorView = nil;
+    [gExternalCursorView removeFromSuperview];
+    [gExternalCursorView release];
+    gExternalCursorView = nil;
     gExternalWindow.hidden = YES;
     [gExternalWindow release];
     gExternalWindow = nil;

--- a/VirtualMac/vz/host/VirtualMacApp.m
+++ b/VirtualMac/vz/host/VirtualMacApp.m
@@ -91,8 +91,15 @@ static void setObj(id object, const char *selector, id value);
 static void sendKey(UIKeyboardHIDUsage usage, BOOL pressed);
 static void sendPointer(CGPoint point, CGRect bounds, NSUInteger pressedButtons);
 static void setStatus(NSString *status);
+// External display (Keynote-style: UIWindow.screen = externalScreen)
+static UIWindow *gExternalWindow;
+static UIView *gExternalMirrorView;
+
 static void updateDisplayGeometry(void);
 static void logFramebufferState(id view, id framebuffer, const char *phase);
+static BOOL externalDisplayEnabled(void);
+static void connectExternalDisplay(void);
+static void disconnectExternalDisplay(void);
 static void startVirtualMachine(UIView *container, id delegate,
                                 NSString *bundlePath,
                                 NSDictionary *options);
@@ -1901,6 +1908,12 @@ static void sendSoftwareChord(UIKeyboardHIDUsage usage, BOOL shifted,
     [NSNotificationCenter.defaultCenter addObserver:self
         selector:@selector(peripheralChanged:)
         name:GCMouseDidDisconnectNotification object:nil];
+    [NSNotificationCenter.defaultCenter addObserver:self
+        selector:@selector(externalScreenChanged:)
+        name:UIScreenDidConnectNotification object:nil];
+    [NSNotificationCenter.defaultCenter addObserver:self
+        selector:@selector(externalScreenChanged:)
+        name:UIScreenDidDisconnectNotification object:nil];
 }
 
 - (void)peripheralChanged:(NSNotification *)notification
@@ -1914,6 +1927,17 @@ static void sendSoftwareChord(UIKeyboardHIDUsage usage, BOOL shifted,
         [gInputView resignFirstResponder];
     }
     [self updateHUDVisibility];
+}
+
+- (void)externalScreenChanged:(NSNotification *)notification
+{
+    (void)notification;
+    if ([notification.name isEqualToString:UIScreenDidConnectNotification]) {
+        if (externalDisplayEnabled())
+            connectExternalDisplay();
+    } else {
+        disconnectExternalDisplay();
+    }
 }
 
 - (void)appSettingsChanged:(NSNotification *)notification
@@ -2035,8 +2059,25 @@ static void sendSoftwareChord(UIKeyboardHIDUsage usage, BOOL shifted,
         [placements addObject:move];
     }
     UIMenu *moveMenu = [UIMenu menuWithTitle:VZL(@"Move Controls") children:placements];
+    // External Display toggle
+    BOOL extEnabled = [VZAppSettings.sharedSettings
+        boolForKey:VZExternalDisplayEnabledKey];
+    UIAction *extToggle = [UIAction actionWithTitle:VZL(@"Fullscreen Mirroring")
+        image:[UIImage systemImageNamed:@"display"]
+        identifier:nil handler:^(UIAction *action) {
+        (void)action;
+        BOOL now = ![VZAppSettings.sharedSettings
+            boolForKey:VZExternalDisplayEnabledKey];
+        [VZAppSettings.sharedSettings setBool:now
+            forKey:VZExternalDisplayEnabledKey];
+        if (now && externalDisplayEnabled())
+            connectExternalDisplay();
+        else if (!now)
+            disconnectExternalDisplay();
+    }];
+    extToggle.state = extEnabled ? UIMenuElementStateOn : UIMenuElementStateOff;
     return [UIMenu menuWithTitle:@""
-        children:@[library, shutdown, hide, moveMenu]];
+        children:@[library, shutdown, hide, extToggle, moveMenu]];
 }
 
 - (void)confirmForceShutdown
@@ -2713,6 +2754,7 @@ static void VZWriteInstallationAttempt(NSString *attemptPath, NSString *state,
 
 - (void)finishVMAndShowLibraryWithError:(NSError *)error
 {
+    disconnectExternalDisplay();
     [gDisplayLayer removeFromSuperlayer];
     gDisplayLayer = nil;
     gDisplayContainer = nil;
@@ -2846,6 +2888,9 @@ static void traceFrameUpdate(id self, SEL selector, id framebuffer,
                shared ? shared->control : NULL);
     ((void(*)(id, SEL, id, VZFrameUpdateSharedPtr))gOriginalFrameUpdate)(
         self, selector, framebuffer, update);
+    // Mirror rendered frame to external display.
+    if (gExternalMirrorView && gDisplayLayer)
+        gExternalMirrorView.layer.contents = gDisplayLayer.contents;
 }
 
 static UIImage *copyCursorImage(const uint8_t *cursor) {
@@ -3591,6 +3636,8 @@ static void activateFramebuffer(void) {
         logFramebufferState(view, framebuffer, "after-2s");
     });
     setStatus(VZL(@"Virtual Mac running — native PVG framebuffer attached"));
+    if (externalDisplayEnabled())
+        connectExternalDisplay();
 }
 
 typedef struct {
@@ -3801,6 +3848,80 @@ static void startVirtualMachine(UIView *container, id delegate,
         return;
     }
     startVirtualMachineWorker(container, delegate, bundlePath, options);
+}
+
+// ─── External Display (Keynote-style) ────────────────────────────────────────
+// Keynote and other presentation apps use UIWindow.screen = externalScreen
+// to take over an external display without system-level borders. UIScene's
+// UIWindowSceneSessionRoleExternalDisplay can add display-specific insets
+// that appear as black bars.
+
+static BOOL externalDisplayEnabled(void) {
+    return [VZAppSettings.sharedSettings boolForKey:VZExternalDisplayEnabledKey]
+        && gFramebuffer != nil;
+}
+
+static void connectExternalDisplay(void) {
+    if (gExternalWindow)
+        return;
+    if (![VZAppSettings.sharedSettings boolForKey:VZExternalDisplayEnabledKey])
+        return;
+    UIScreen *extScreen = nil;
+    for (UIScreen *s in UIScreen.screens) {
+        if (s != UIScreen.mainScreen) {
+            extScreen = s;
+            break;
+        }
+    }
+    if (!extScreen)
+        return;
+
+    // Disable overscan compensation so the system doesn't scale/inset
+    // the display output. Without this, nativeBounds may differ from
+    // bounds, introducing system-level black borders.
+    extScreen.overscanCompensation = 2;  // UIScreenOverscanCompensationNone
+
+    printf("[VirtualMac] external display connecting screen=%s "
+           "bounds=%.0fx%.0f native=%.0fx%.0f scale=%.3f "
+           "overscanCompensation=%ld\n",
+           extScreen.description.UTF8String,
+           extScreen.bounds.size.width, extScreen.bounds.size.height,
+           extScreen.nativeBounds.size.width, extScreen.nativeBounds.size.height,
+           extScreen.scale,
+           (long)extScreen.overscanCompensation);
+    for (UIScreenMode *mode in extScreen.availableModes) {
+        printf("[VirtualMac] ext screen mode size=%.0fx%.0f "
+               "pixelAspectRatio=%.3f\n",
+               mode.size.width, mode.size.height,
+               mode.pixelAspectRatio);
+    }
+
+    gExternalWindow = [[UIWindow alloc] initWithFrame:extScreen.bounds];
+    gExternalWindow.screen = extScreen;
+    gExternalWindow.backgroundColor = [UIColor blackColor];
+
+    UIView *mirrorView = [[UIView alloc] initWithFrame:gExternalWindow.bounds];
+    mirrorView.backgroundColor = [UIColor blackColor];
+    mirrorView.autoresizingMask = UIViewAutoresizingFlexibleWidth
+                                | UIViewAutoresizingFlexibleHeight;
+    mirrorView.layer.contentsGravity = kCAGravityResizeAspect;
+    [gExternalWindow addSubview:mirrorView];
+    gExternalMirrorView = mirrorView;
+    [mirrorView release];
+
+    gExternalWindow.hidden = NO;
+    printf("[VirtualMac] external window created frame=%s\n",
+           NSStringFromCGRect(gExternalWindow.frame).UTF8String);
+}
+
+static void disconnectExternalDisplay(void) {
+    if (!gExternalWindow)
+        return;
+    printf("[VirtualMac] external display disconnecting\n");
+    gExternalMirrorView = nil;
+    gExternalWindow.hidden = YES;
+    [gExternalWindow release];
+    gExternalWindow = nil;
 }
 
 @interface VirtualMacAppDelegate : UIResponder <UIApplicationDelegate>

--- a/VirtualMac/vz/host/VirtualMacApp.m
+++ b/VirtualMac/vz/host/VirtualMacApp.m
@@ -100,6 +100,7 @@ static void updateDisplayGeometry(void);
 static void logFramebufferState(id view, id framebuffer, const char *phase);
 static BOOL externalDisplayEnabled(void);
 static void connectExternalDisplay(void);
+static void connectExternalDisplayWithScreen(UIScreen *screen);
 static void disconnectExternalDisplay(void);
 static void startVirtualMachine(UIView *container, id delegate,
                                 NSString *bundlePath,
@@ -1932,10 +1933,12 @@ static void sendSoftwareChord(UIKeyboardHIDUsage usage, BOOL shifted,
 
 - (void)externalScreenChanged:(NSNotification *)notification
 {
-    (void)notification;
     if ([notification.name isEqualToString:UIScreenDidConnectNotification]) {
-        if (externalDisplayEnabled())
-            connectExternalDisplay();
+        // Use the screen from the notification directly — UIScreen.screens
+        // may not be updated yet at the time this notification fires.
+        UIScreen *screen = notification.object;
+        if (screen && screen != UIScreen.mainScreen && externalDisplayEnabled())
+            connectExternalDisplayWithScreen(screen);
     } else {
         disconnectExternalDisplay();
     }
@@ -3884,16 +3887,17 @@ static BOOL externalDisplayEnabled(void) {
         && gFramebuffer != nil;
 }
 
-static void connectExternalDisplay(void) {
+static void connectExternalDisplayWithScreen(UIScreen *extScreen) {
     if (gExternalWindow)
         return;
     if (![VZAppSettings.sharedSettings boolForKey:VZExternalDisplayEnabledKey])
         return;
-    UIScreen *extScreen = nil;
-    for (UIScreen *s in UIScreen.screens) {
-        if (s != UIScreen.mainScreen) {
-            extScreen = s;
-            break;
+    if (!extScreen) {
+        for (UIScreen *s in UIScreen.screens) {
+            if (s != UIScreen.mainScreen) {
+                extScreen = s;
+                break;
+            }
         }
     }
     if (!extScreen)
@@ -3940,6 +3944,10 @@ static void connectExternalDisplay(void) {
     gExternalWindow.hidden = NO;
     printf("[VirtualMac] external window created frame=%s\n",
            NSStringFromCGRect(gExternalWindow.frame).UTF8String);
+}
+
+static void connectExternalDisplay(void) {
+    connectExternalDisplayWithScreen(nil);
 }
 
 static void disconnectExternalDisplay(void) {


### PR DESCRIPTION
## Summary

Adds fullscreen mirroring support for external displays using the same approach as Keynote: `UIWindow.screen = externalScreen` with `UIScreenDidConnectNotification`, rather than `UIWindowSceneSessionRoleExternalDisplay` (which adds system-level borders on some displays).

## Approach

**Keynote-style external display takeover:**
- Listens for `UIScreenDidConnectNotification`/`UIScreenDidDisconnectNotification`
- Creates a `UIWindow` directly on the external screen via `window.screen = externalScreen`
- Sets `overscanCompensation = UIScreenOverscanCompensationNone` to prevent system-level scaling borders (fixes black bars when `nativeBounds != bounds`)

**Framebuffer mirroring:**
- Copies the rendered framebuffer IOSurface (`gDisplayLayer.contents`) to a plain `CALayer` on the external window each frame
- Uses `kCAGravityResizeAspect` so short edges are flush and bars appear only on the long edges

**Mouse cursor mirroring:**
- Mirrors the guest cursor overlay to the external display, scaled to the aspect-fit viewport

**HUD toggle:**
- "Fullscreen Mirroring" toggle always visible in the HUD menu
- External display is only taken over when toggle is ON AND a VM is running
- Handles plug/unplug, VM start/stop, and toggle ON/OFF

## Testing
- [x] Connect 4K external display, toggle ON, start VM → framebuffer mirrors without system borders
- [x] Toggle OFF → external display returns to system mirroring
- [x] Unplug display → clean disconnect, no crash
- [x] Plug display while VM running → auto-connects
- [x] Start VM with display connected and toggle ON → auto-connects
- [x] Mouse cursor visible and correctly positioned on external display

Test Device: iPad Pro M2 with iPadOS 16.0

<img width="1280" height="960" alt="2f30b140bc4e438aea11d0af17e736e5_720" src="https://github.com/user-attachments/assets/f77b1575-fb07-452d-9e99-8ada2fcec82c" />
<img width="2388" height="1668" alt="截屏 2026-08-12 03 16 02" src="https://github.com/user-attachments/assets/2399cfb1-698d-4421-84b3-ef0ee83bcfe4" />
<img width="1920" height="1080" alt="截屏 2026-08-12 03 16 02 2" src="https://github.com/user-attachments/assets/239e347d-6100-4284-a98f-6396c0696c97" />


## Limitations

Used some deprecated API like setScreen. I tried UIScene approach but the windowbox was so stubborn.

Partially implemented #33.

Made with love ❤️