### PR TITLE
Add Apple Pencil hover and coalesced touch relay

### DIFF
--- a/VirtualMac/vz/host/VirtualMacApp.m
+++ b/VirtualMac/vz/host/VirtualMacApp.m
@@ -2450,18 +2450,26 @@ static bool pencilVsockSend(uint8_t type, float pressure,
     // type=0 (point) for continuous drag events.
     if (_vzPencilRelayStrokeClaimed) for (UITouch *t in touches) {
         if (t.type == UITouchTypeStylus) {
-            CGPoint p = [t locationInView:self];
             CGRect b = self.bounds;
-            float pressure = (t.maximumPossibleForce > 0)
-                ? (float)(t.force / t.maximumPossibleForce) : 0;
-            float nx = (b.size.width > 0) ? (float)(p.x / b.size.width) : 0;
-            float ny = (b.size.height > 0) ? (float)(p.y / b.size.height) : 0;
-            float altitude = (float)t.altitudeAngle;
-            float azimuth = (float)[t azimuthAngleInView:self];
-            if (_vzPencilRelayStrokeConnected)
-                _vzPencilRelayStrokeConnected = pencilVsockSend(
-                    kPencilEventPoint, pressure, nx, ny,
-                    altitude, azimuth);
+            // coalescedTouchesForTouch: が返す中間タッチをすべて送信し、
+            // iPad の 240Hz サンプリングに近い描画解像度を得る。
+            // nil の場合は現タッチ 1 つだけ送信（フォールバック）。
+            NSArray<UITouch *> *coalesced = [event coalescedTouchesForTouch:t];
+            if (!coalesced) coalesced = @[t];
+            for (UITouch *ct in coalesced) {
+                CGPoint p = [ct locationInView:self];
+                float pressure = (ct.maximumPossibleForce > 0)
+                    ? (float)(ct.force / ct.maximumPossibleForce) : 0;
+                float nx = (b.size.width > 0) ? (float)(p.x / b.size.width) : 0;
+                float ny = (b.size.height > 0) ? (float)(p.y / b.size.height) : 0;
+                float altitude = (float)ct.altitudeAngle;
+                float azimuth = (float)[ct azimuthAngleInView:self];
+                if (_vzPencilRelayStrokeConnected)
+                    _vzPencilRelayStrokeConnected = pencilVsockSend(
+                        kPencilEventPoint, pressure, nx, ny,
+                        altitude, azimuth);
+                if (!_vzPencilRelayStrokeConnected) break;
+            }
             return;
         }
     }

--- a/VirtualMac/vz/host/VirtualMacApp.m
+++ b/VirtualMac/vz/host/VirtualMacApp.m
@@ -1510,6 +1510,7 @@ static void sendSoftwareKey(UIKeyboardHIDUsage usage, BOOL shifted);
     BOOL _vzDirectPrimaryPressed;
     BOOL _vzPencilRelayStrokeClaimed;
     BOOL _vzPencilRelayStrokeConnected;
+    BOOL _vzPencilHoverActive;
 }
 @end
 
@@ -1734,12 +1735,26 @@ static void sendSoftwareChord(UIKeyboardHIDUsage usage, BOOL shifted,
     CGPoint location = [recognizer locationInView:self];
     switch (recognizer.state) {
     case UIGestureRecognizerStateBegan:
-        gUIKitHoverActive = YES;
-        sendIndirectPointerLocation(location, self.bounds);
-        break;
     case UIGestureRecognizerStateChanged:
         gUIKitHoverActive = YES;
         sendIndirectPointerLocation(location, self.bounds);
+        // Apple Pencil hover: zOffset > 0 distinguishes Pencil from
+        // trackpad. Send hover position + tilt to the guest VM so
+        // drawing apps can show brush previews before the pen touches.
+        if (@available(iOS 16.4, *)) {
+            if (pencilRelayEnabled() && recognizer.zOffset > 0) {
+                _vzPencilHoverActive = YES;
+                CGRect b = self.bounds;
+                float nx = (b.size.width > 0)
+                    ? (float)(location.x / b.size.width) : 0;
+                float ny = (b.size.height > 0)
+                    ? (float)(location.y / b.size.height) : 0;
+                float altitude = (float)recognizer.altitudeAngle;
+                float azimuth = (float)[recognizer azimuthAngleInView:self];
+                pencilVsockSend(kPencilEventHover, 0, nx, ny,
+                                altitude, azimuth);
+            }
+        }
         break;
     case UIGestureRecognizerStateEnded:
     case UIGestureRecognizerStateCancelled:
@@ -1750,6 +1765,19 @@ static void sendSoftwareChord(UIKeyboardHIDUsage usage, BOOL shifted,
         // stuck-button cleanup instead.
         gUIKitHoverActive = NO;
         gHostPointerLocationValid = NO;
+        // Notify the guest that the Pencil left hover range.
+        // If the pen touched the screen (hover → touch transition),
+        // pencil-probe's state machine handles the brief leave/enter.
+        if (_vzPencilHoverActive) {
+            _vzPencilHoverActive = NO;
+            CGRect b = self.bounds;
+            float nx = (b.size.width > 0)
+                ? (float)(location.x / b.size.width) : 0;
+            float ny = (b.size.height > 0)
+                ? (float)(location.y / b.size.height) : 0;
+            pencilVsockSend(kPencilEventHoverEnd, 0, nx, ny,
+                            (float)M_PI_2, 0);
+        }
         break;
     default:
         break;
@@ -2175,6 +2203,8 @@ enum { kPencilPacketSize = 21 };
 static const uint8_t kPencilEventPoint = 0;
 static const uint8_t kPencilEventProximityEnter = 1;
 static const uint8_t kPencilEventProximityLeave = 2;
+static const uint8_t kPencilEventHover = 3;
+static const uint8_t kPencilEventHoverEnd = 4;
 
 // Wire protocol byte offsets. Must match PencilPacket offsets in pencil-probe.
 enum {
@@ -2451,9 +2481,9 @@ static bool pencilVsockSend(uint8_t type, float pressure,
     if (_vzPencilRelayStrokeClaimed) for (UITouch *t in touches) {
         if (t.type == UITouchTypeStylus) {
             CGRect b = self.bounds;
-            // coalescedTouchesForTouch: が返す中間タッチをすべて送信し、
-            // iPad の 240Hz サンプリングに近い描画解像度を得る。
-            // nil の場合は現タッチ 1 つだけ送信（フォールバック）。
+            // Send all intermediate touches from coalescedTouchesForTouch:
+            // to approach the iPad's 240Hz sampling resolution.
+            // Falls back to the current touch alone when nil.
             NSArray<UITouch *> *coalesced = [event coalescedTouchesForTouch:t];
             if (!coalesced) coalesced = @[t];
             for (UITouch *ct in coalesced) {


### PR DESCRIPTION
## Summary

Building on #49, this adds two enhancements to the Apple Pencil relay:

1. **Coalesced touches** — Send all intermediate samples captured between display refreshes via `coalescedTouchesForTouch:`, approaching the iPad's native 240Hz Pencil sampling rate. Previously only one sample per `touchesMoved` callback (~60Hz) was relayed.

2. **Hover relay** — Relay Apple Pencil hover position to the guest via `UIHoverGestureRecognizer`. Drawing apps can then show hover effects such as brush previews and tooltips as the pen approaches the screen, before contact.

**Changes (VirtualMacApp.m only):**

- Use `coalescedTouchesForTouch:` in `touchesMoved` to iterate all intermediate stylus samples; fall back to the current touch when the array is nil
- Detect Pencil hover via `UIHoverGestureRecognizer` using `zOffset > 0` (iPadOS 16.1+) to distinguish Pencil from trackpad
- Send `kPencilEventHover` (type 3) with position during hover, `kPencilEventHoverEnd` (type 4) when the pen leaves detection range
- Track hover state with `_vzPencilHoverActive` to send `hoverEnd` only when a Pencil hover session is active

**Design decisions:**

- **Backward-compatible:** pencil-probe v2.x (without hover support) silently ignores unknown event types via `guard let` on the raw value. No guest-side update is required for coalesced touches — they use the existing `kPencilEventPoint` type
- **Availability:** `zOffset` was introduced in iPadOS 16.1. Tilt during hover (`altitudeAngle`/`azimuthAngle` on `UIHoverGestureRecognizer`) requires iPadOS 16.4+, which exceeds the Hypervisor-based upper bound (iPadOS 16.3.1) — see #56 for the fix that lowers the guard and sends zeros for tilt fields
- **No extra packets on hover end:** `hoverEnd` sends zero for tilt fields since tilt data is meaningless when the pen leaves range

## Guest-side companion

[pencil-probe](https://github.com/ma-syu/pencil-probe) v3.0.0 adds a `PenState` machine (idle → hovering → touching) that maps hover events to macOS tablet proximity + mouse-moved events for hover effects such as brush previews.

## Test plan

- [x] Coalesced touches produce smoother strokes in Clip Studio Paint at fast drawing speeds
- [x] Brush preview follows Pencil hover position in Clip Studio Paint
- [x] Hover-to-touch and touch-to-hover transitions work cleanly (no stuck cursor or ghost strokes)
- [x] No impact on finger/trackpad input
- [x] Falls back gracefully when pencil-probe is not running (regular mouse mode)
- [x] Falls back gracefully with older pencil-probe versions (hover events ignored, pressure/tilt work)