### PR TITLE
Fix hover availability guard: iOS 16.4 -> 16.1

### DIFF
--- a/VirtualMac/vz/host/VirtualMacApp.m
+++ b/VirtualMac/vz/host/VirtualMacApp.m
@@ -1739,9 +1739,12 @@ static void sendSoftwareChord(UIKeyboardHIDUsage usage, BOOL shifted,
         gUIKitHoverActive = YES;
         sendIndirectPointerLocation(location, self.bounds);
         // Apple Pencil hover: zOffset > 0 distinguishes Pencil from
-        // trackpad. Send hover position + tilt to the guest VM so
-        // drawing apps can show brush previews before the pen touches.
-        if (@available(iOS 16.4, *)) {
+        // trackpad. Send hover position to the guest VM so drawing
+        // apps can show brush previews before the pen touches.
+        // Tilt (altitudeAngle/azimuthAngle) on UIHoverGestureRecognizer
+        // requires iOS 16.4+, which exceeds the Hypervisor-based upper
+        // bound (iPadOS 16.3.1), so we send zeros for tilt fields.
+        if (@available(iOS 16.1, *)) {
             if (pencilRelayEnabled() && recognizer.zOffset > 0) {
                 _vzPencilHoverActive = YES;
                 CGRect b = self.bounds;
@@ -1749,10 +1752,7 @@ static void sendSoftwareChord(UIKeyboardHIDUsage usage, BOOL shifted,
                     ? (float)(location.x / b.size.width) : 0;
                 float ny = (b.size.height > 0)
                     ? (float)(location.y / b.size.height) : 0;
-                float altitude = (float)recognizer.altitudeAngle;
-                float azimuth = (float)[recognizer azimuthAngleInView:self];
-                pencilVsockSend(kPencilEventHover, 0, nx, ny,
-                                altitude, azimuth);
+                pencilVsockSend(kPencilEventHover, 0, nx, ny, 0, 0);
             }
         }
         break;


### PR DESCRIPTION
## Summary

Follow-up to #54 — addresses the review comment about the unreachable `@available(iOS 16.4, *)` block.

The entire Pencil hover relay block (zOffset detection + vsock send) was gated behind `@available(iOS 16.4, *)`, making it dead code since the Hypervisor framework was removed in iPadOS 16.4. Cursor tracking during hover worked via `sendIndirectPointerLocation` (no availability guard), but the Pencil-specific vsock path never executed.

This PR:
- Lowers the guard to `@available(iOS 16.1, *)` so `zOffset`-based Pencil hover detection becomes reachable for the first time
- Removes `altitudeAngle`/`azimuthAngle` from the hover handler (requires iOS 16.4+, permanently unreachable) and sends zeros for tilt fields
- Touch handler tilt data is unaffected (`UITouch.altitudeAngle` is available since iOS 9.1)

## Details

| API | Introduced | Usable (≤ iPadOS 16.3.1)? |
|---|---|---|
| `UIHoverGestureRecognizer.zOffset` | iOS 16.1 | Yes |
| `UIHoverGestureRecognizer.altitudeAngle` | iOS 16.4 | No (dead code) |
| `UIHoverGestureRecognizer.azimuthAngle` | iOS 16.4 | No (dead code) |
| `UITouch.altitudeAngle` (touch handler) | iOS 9.1 | Yes (unchanged) |